### PR TITLE
changed instances of this.url.path to this.url.pathname, this being the c

### DIFF
--- a/lib/WebSocketClient.js
+++ b/lib/WebSocketClient.js
@@ -125,7 +125,7 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin) {
         host: this.url.hostname,
         port: this.url.port,
         method: 'GET',
-        path: this.url.path
+        path: this.url.pathname
     };
     
     var hostHeaderValue = this.url.hostname;
@@ -165,7 +165,7 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin) {
         s.validateHandshake();
     });
 
-    var req = this.request = client.request(this.url.path, reqHeaders);
+    var req = this.request = client.request(this.url.pathname, reqHeaders);
 
     req.on('response', function(response) {
         s.failHandshake("Server responded with a non-101 status: " + response.statusCode);


### PR DESCRIPTION
changed instances of this.url.path to this.url.pathname, this being the correct fieldname resulting from a url.parse call. Now the client sends the correct path to the server
