### PR TITLE
Connect failed for web socket clients

### DIFF
--- a/lib/WebSocketClient.js
+++ b/lib/WebSocketClient.js
@@ -169,14 +169,6 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin) {
     }
     client.on('error', handleRequestError);
 
-    client.on('upgrade', function handleClientUpgrade(response, socket, head) {
-        req.removeListener('error', handleRequestError);
-        s.socket = socket;
-        s.response = response;
-        s.firstDataChunk = head;
-        s.validateHandshake();
-    });
-
     var pathAndQuery = this.url.pathname;
     if (this.url.search) {
         pathAndQuery += this.url.search;
@@ -186,6 +178,14 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin) {
 
     req.on('response', function(response) {
         s.failHandshake("Server responded with a non-101 status: " + response.statusCode);
+    });
+
+    req.on('upgrade', function handleClientUpgrade(response, socket, head) {
+        req.removeListener('error', handleRequestError);
+        s.socket = socket;
+        s.response = response;
+        s.firstDataChunk = head;
+        s.validateHandshake();
     });
     
     req.end();


### PR DESCRIPTION
The sample client code on https://github.com/Worlize/WebSocket-Node fails due to the fact that the upgrade never happens and, as such, the connection never completes.  I've fixed this issue in my fork.
