### PR TITLE
Optional Set Cookie Header in WebSocketRequest.accept

### DIFF
--- a/lib/WebSocketRequest.js
+++ b/lib/WebSocketRequest.js
@@ -210,7 +210,28 @@ WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, co
     
     if (cookies) {
     	for(var c in cookies){
-    		response += "Set-Cookie: " + cookies[c] + "\r\n";
+    		var cookie = cookies[c];
+    		if(!cookie.name || !cookie.value) throw new Error("No cookie name value pair specified in cookie");
+    		
+    		//token
+    		var invalidChar = cookie.name.match(/([\x00-\x20\x22\x28\x29\x2c\x2f\x3a-\x3f\x40\x5b-\x5e\x7b\x7d\x7f])/);
+    		if(invalidChar) throw new Error("Illegal character(s) " + invalidChar[0] + " in cookie name");
+    		
+    		// *cookie-octet / ( DQUOTE *cookie-octet DQUOTE ) | %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
+    		invalidChar = cookie.value.match(/[\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]/) //TODO: add double quote handling
+    		if(invalidChar) throw new Error("Illegal character(s) " + invalidChar[0] + " in cookie name");
+    		
+    		
+    		response += "Set-Cookie: " + cookie.name + "="  + cookie.value + ";";
+    		if(cookie.expires)  response += "Expires=" + cookie.expires + ";";
+    		if(cookie.maxage)  response += "Max-Age=" + cookie.maxage + ";";
+    		if(cookie.domain)  response += "Domain=" + cookie.domain + ";";
+    		if(cookie.path)  response += "Expires=" + cookie.path + ";";
+    		if(cookie.secure)  response += "Secure;";
+    		if(cookie.httponly)  response += "HttpOnly;";
+    		
+    		response += "\r\n";
+    		
     	}	
     }
     // TODO: handle negotiated extensions


### PR DESCRIPTION
I don't know if you are interested, but I added some very simple cookie functionality to the WebSocketRequest.accept method. I thought it might be useful for establishing session ids and what not.
