### PR TITLE
More RCF validation for Set Cookie header

### DIFF
--- a/lib/WebSocketRequest.js
+++ b/lib/WebSocketRequest.js
@@ -36,6 +36,8 @@ for (var i=0; i < 31; i ++) {
 
 var cookieNameValidateRegEx = /([\x00-\x20\x22\x28\x29\x2c\x2f\x3a-\x3f\x40\x5b-\x5e\x7b\x7d\x7f])/;
 var cookieValueValidateRegEx = /[^\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]/;
+var cookieValueDQuoteValidateRegEx = /^".*"$/;
+var cookiePathValidateRegEx = /[\x00-\x20\x3b]/;
 
 var httpStatusDescriptions = {
     100: "Continue",
@@ -236,33 +238,83 @@ WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, co
     		
     		// RFC 6265, Section 4.1.1
     		// *cookie-octet / ( DQUOTE *cookie-octet DQUOTE ) | %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
-    		// TODO: add double quote handling
-    		invalidChar = cookie.value.match(cookieValueValidateRegEx);
-    		if (invalidChar) {
-    		    this.reject(500);
-    		    throw new Error("Illegal character(s) " + invalidChar[0] + " in cookie value");
-    		}
+    		if(cookie.value.match(cookieValueDQuoteValidateRegEx)){
+				invalidChar = cookie.value.slice(1, -1).match(cookieValueValidateRegEx);
+			}else {
+				invalidChar = cookie.value.match(cookieValueValidateRegEx);
+			}
+			if (invalidChar) {
+				this.reject(500);
+			    throw new Error("Illegal character(s) " + invalidChar[0] + " in cookie value");
+			}
     		
     		var cookieParts = [cookie.name + "=" + cookie.value];
     		
-    		if (cookie.expires) {
-    		    cookieParts.push("Expires=" + cookie.expires);
+    		// RFC 6265, Section 4.1.1
+    		// "Path=" path-value | <any CHAR except CTLs or ";">
+    		if(cookie.path){
+    			invalidChar = cookie.path.match(cookiePathValidateRegEx);
+    			if (invalidChar) {
+    				this.reject(500);
+    				if(invalidChar) throw new Error("Illegal character " + invalidChar[0] + " in cookie path");
+    			}
+    			cookieParts.push("Path=" + cookie.path);
     		}
-    		if (cookie.maxage) {
-    		    cookieParts.push("Max-Age=" + cookie.maxage.toString());
+    		
+    		// RFC 6265, Section 4.1.2.3
+    		// "Domain=" subdomain 
+    		// TODO: add validation against TLDs
+    		if(cookie.domain){
+    			// It was easier to match the origin against the supplied domain rather than the other way around
+    			var cookieDomainValidateRegEx = new RegExp("^[a-zA-Z0-9-]*\\.*" + cookie.domain.toLowerCase().replace(/\./g,"\\.+") + "$");
+    			var origin = allowedOrigin.replace("http://","");
+    			
+    			if(!origin.match(cookieDomainValidateRegEx)){
+    				this.reject(500);
+    				throw new Error("Value supplied for cookie 'domain' must be a vaild subdomain of " + origin);
+    			} 
+    			cookieParts.push("Domain=" + cookie.domain.toLowerCase());
     		}
-    		if (cookie.domain) {
-    		    cookieParts.push("Domain=" + cookie.domain);
+    		
+    		// RFC 6265, Section 4.1.1
+    		//"Expires=" sane-cookie-date | Force Date object requirement by using only epoch
+    		if(cookie.expires){
+    			if(typeof cookie.expires.getTime !== "function" || typeof cookie.expires.getTime() !== "number"){
+    				this.reject(500);
+    				throw new Error("Value supplied for cookie 'expires' must be a vaild date object");
+    			} 
+    			cookieParts.push("Expires=" +  new Date(cookie.expires.getTime()).toGMTString());
+    		} 
+    		
+    		// RFC 6265, Section 4.1.1
+    		//"Max-Age=" non-zero-digit *DIGIT
+    		if(cookie.maxage){
+    			if(isNaN(parseInt(cookie.maxage)) || parseInt(cookie.maxage) <= 0){
+    				this.reject(500);
+    				throw new Error("Value supplied for cookie 'maxage' must be a non-zero digit");
+    			}
+    			cookieParts.push("Max-Age=" + cookie.maxage.toString());
     		}
-    		if (cookie.path) {
-    		    cookieParts.push("Expires=" + cookie.path);
+    		
+    		// RFC 6265, Section 4.1.1
+    		//"Secure;"
+    		if(cookie.secure){
+    			if(typeof cookie.secure !== "boolean"){
+    				this.reject(500);
+    				throw new Error("Value supplied for cookie 'secure' must be of type boolean");
+    			}
+    			cookieParts.push("Secure");
     		}
-    		if (cookie.secure) {
-    		    cookieParts.push("Secure");
-    		}
-    		if (cookie.httponly) {
-    		    cookieParts.push("HttpOnly");
-    		}
+    		
+    		// RFC 6265, Section 4.1.1
+    		//"HttpOnly;"
+    		if(cookie.httponly){
+    			if(typeof cookie.httponly !== "boolean"){
+    				this.reject(500);
+    				throw new Error("Value supplied for cookie 'httponly' must be of type boolean");
+    			}
+    			cookieParts.push("HttpOnly");
+    		} 
     		
     		response += ("Set-Cookie: " + cookieParts.join(';') + "\r\n");
     	}.bind(this));	


### PR DESCRIPTION
I added some more validation to the set cookie header functionality. It's mostly just forced object types and reconstruction. I still need to add a subdomain check against the allowedOrigin. Also I just thought I should do another pull request at this point because I realized last night that I inverted the logic in the cookie.value regexp. Notice the new hat :)
I know it might be a bit bulky but I figured you could take or leave whatever.
