### PR TITLE
This commit should give you up to 2x performance improvement

### DIFF
--- a/vendor/FastBufferList.js
+++ b/vendor/FastBufferList.js
@@ -71,8 +71,7 @@ function BufferList(opts) {
         if (!head.buffer) return new self.construct(0);
         
         if (head.buffer.length - offset <= 0) return self;
-        var firstBuf = new self.construct(head.buffer.length - offset);
-        head.buffer.copy(firstBuf, 0, offset, head.buffer.length);
+        var firstBuf = head.buffer.slice(offset);
         
         var b = { buffer : firstBuf, next : head.next };
         


### PR DESCRIPTION
I found unnecessary "new Buffer()" in FastBufferList.js

Fixing this problem resulted in 2x performance improvement. I measured client -> server -> client latency by sending binary data.

Benchmarked with
https://github.com/kazuyukitanimura/WebSocket-Node-binaryTransferBenchmark

Thanks
