### PR TITLE
Fix sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ wsServer.on('request', function(request) {
       return;
     }
     
-    var connection = request.accept(null, request.origin);
+    var connection = request.accept('echo-protocol', request.origin);
     console.log((new Date()) + ' Connection accepted.');
     connection.on('message', function(message) {
         if (message.type === 'utf8') {


### PR DESCRIPTION
When calling `accept` without a protocol, the client fails to connect on:

```
Connect Error: Expected a Sec-WebSocket-Protocol header.
```
