### PR TITLE
Add a proper .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+.npmignore
+.gitignore
+
+CHANGELOG.md
+README.md
+LICENSE
+
+example/
+build/
+build/.wafpickle-7
+test/
+
+vendor/node-ctype/README
+vendor/node-ctype/ctio.js
+vendor/node-ctype/ctype.js
+vendor/node-ctype/tst/

--- a/example/whiteboard/README
+++ b/example/whiteboard/README
@@ -1,6 +1,6 @@
 To run the whiteboard example, make sure to run..
 
-npm install
+npm install "express@2.3.11" "ejs@0.4.3"
 
 ..from within the 'whiteboard' folder, then fire up the example server with..
 

--- a/example/whiteboard/package.json
+++ b/example/whiteboard/package.json
@@ -1,9 +1,0 @@
-{
-    "name": "websocket-whiteboard"
-  , "description": "example whiteboard application with websockets"
-  , "version": "0.0.1"
-  , "dependencies": {
-        "express": "2.3.11",
-        "ejs": "0.4.3"
-    }
-}


### PR DESCRIPTION
I order to keep the package small, only include the really necessary files in it. Tests, readme, changelog etc are not needed. This commit adds proper .npmignore file to do that. I had to remove the package.json from the whiteboard example because npm will _not_ ignore directories with a package.json in them, and there is no way to override that behavior other than to remove the package.json file.
