### PR TITLE
Fix global leak in WebSocketFrame.

### DIFF
--- a/lib/WebSocketFrame.js
+++ b/lib/WebSocketFrame.js
@@ -237,7 +237,7 @@ WebSocketFrame.prototype.toBuffer = function(nullMask) {
         headerLength += 8;
     }
 
-    output = new Buffer(this.length + headerLength + (this.mask ? 4 : 0));
+    var output = new Buffer(this.length + headerLength + (this.mask ? 4 : 0));
 
     // write the frame header
     output[0] = firstByte;


### PR DESCRIPTION
I found global leak in WebSocketFrame.prototype.toBuffer.
