### PR TITLE
Added the NODE_MODULE macro in validation.cc.

### DIFF
--- a/src/validation.cc
+++ b/src/validation.cc
@@ -140,3 +140,5 @@ extern "C" void init (Handle<Object> target)
   HandleScope scope;
   Validation::Initialize(target);
 }
+
+NODE_MODULE(validation, init);


### PR DESCRIPTION
Added the NODE_MODULE macro in validation.cc. This is required in windows to locate the module entry. Otherwise the module fails to load with system error code 127.
