### PR TITLE
Patch native compilation warnings.

### DIFF
--- a/src/validation.cc
+++ b/src/validation.cc
@@ -68,7 +68,7 @@ static int isLegalUTF8(const uint8_t *source, const int length)
 int is_valid_utf8 (size_t len, char *value)
 {
   /* is the string valid UTF-8? */
-  for (int i = 0; i < len; i++) {
+  for (size_t i = 0; i < len; i++) {
     uint32_t ch = 0;
     uint8_t  extrabytes = trailingBytesForUTF8[(uint8_t) value[i]];
 


### PR DESCRIPTION
Fixes these warnings.

```
> node-gyp rebuild

  CXX(target) Release/obj.target/validation/src/validation.o
../src/validation.cc:71:21: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
  for (int i = 0; i < len; i++) {
                  ~ ^ ~~~
../src/validation.cc:75:24: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
    if (extrabytes + i >= len)
        ~~~~~~~~~~~~~~ ^  ~~~
../src/validation.cc:144:1: warning: no newline at end of file [-pedantic,-Wnewline-eof]

^
```
