### PR TITLE
Add cstring include to native XOR.

### DIFF
--- a/src/xor.cpp
+++ b/src/xor.cpp
@@ -7,6 +7,7 @@
 
 #include <v8.h>
 #include <node_buffer.h>
+#include <cstring>
 
 using namespace node;
 using namespace v8;


### PR DESCRIPTION
The previous includes are sufficient for Ubuntu and Mac, but for whatever
reason, cstring is necessary for memcpy on CentOS.

```
  CXX(target) Release/obj.target/xor/src/xor.o
../src/xor.cpp: In function ‘v8::Handle<v8::Value><unnamed>::xorBuffer(const v8::Arguments&)’:
../src/xor.cpp:56: error: ‘memcpy’ was not declared in this scope
make: *** [Release/obj.target/xor/src/xor.o] Error 1
make: Leaving directory
```
