### PR TITLE
WebSocketClient: always use Error objects on error

### DIFF
--- a/lib/WebSocketClient.js
+++ b/lib/WebSocketClient.js
@@ -334,7 +334,7 @@ WebSocketClient.prototype.failHandshake = function(errorDescription) {
     if (this.socket && this.socket.writable) {
         this.socket.end();
     }
-    this.emit('connectFailed', errorDescription);
+    this.emit('connectFailed', new Error(errorDescription));
 };
 
 WebSocketClient.prototype.succeedHandshake = function() {


### PR DESCRIPTION
when connectFailed is emitted via failHandshake() a string is emitted
if connectFailed is emitted via handleRequestError, and thus via
http.ClientRequest, an Error object is used.

This patch attempts to streamline the use of Error objects.
