### PR TITLE
Added support for the rejectUnauthorized tls option for websocket client

### DIFF
--- a/lib/WebSocketClient.js
+++ b/lib/WebSocketClient.js
@@ -246,7 +246,7 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
             agent: false
         };
         if (this.secure) {
-            ['key','passphrase','cert','ca'].forEach(function(key) {
+            ['key','passphrase','cert','ca','rejectUnauthorized'].forEach(function(key) {
                 if (self.config.tlsOptions.hasOwnProperty(key)) {
                     requestOptions[key] = self.config.tlsOptions[key];
                 }


### PR DESCRIPTION
Sometimes firewalls make it such that the client will not connect the tls connection. Allowing this option will allow the websocketClient to work around these cases.
