### PR TITLE
Add support for the secureProtocol TLS option.

### DIFF
--- a/lib/WebSocketClient.js
+++ b/lib/WebSocketClient.js
@@ -1,12 +1,12 @@
 /************************************************************************
  *  Copyright 2010-2011 Worlize Inc.
- *  
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- *  
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -46,7 +46,7 @@ var protocolSeparators = [
 
 function WebSocketClient(config) {
     // TODO: Implement extensions
-    
+
     this.config = {
         // 1MiB max frame size.
         maxReceivedFrameSize: 0x100000,
@@ -54,22 +54,22 @@ function WebSocketClient(config) {
         // 8MiB max message size, only applicable if
         // assembleFragments is true
         maxReceivedMessageSize: 0x800000,
-        
+
         // Outgoing messages larger than fragmentationThreshold will be
         // split into multiple fragments.
         fragmentOutgoingMessages: true,
-        
+
         // Outgoing frames are fragmented if they exceed this threshold.
         // Default is 16KiB
         fragmentationThreshold: 0x4000,
-        
+
         // Which version of the protocol to use for this session.  This
         // option will be removed once the protocol is finalized by the IETF
         // It is only available to ease the transition through the
         // intermediate draft protocol versions.
         // At present, it only affects the name of the Origin header.
         webSocketVersion: 13,
-        
+
         // If true, fragmented messages will be automatically assembled
         // and the full message will be emitted via a 'message' event.
         // If false, each frame will be emitted via a 'frame' event and
@@ -78,7 +78,7 @@ function WebSocketClient(config) {
         // event in addition to the 'frame' event.
         // Most users will want to leave this set to 'true'
         assembleFragments: true,
-        
+
         // The Nagle Algorithm makes more efficient use of network resources
         // by introducing a small delay before sending small packets so that
         // multiple messages can be batched together before going onto the
@@ -91,7 +91,7 @@ function WebSocketClient(config) {
         // for an acknowledgement to come back before giving up and just
         // closing the socket.
         closeTimeout: 5000,
-        
+
         // Options to pass to https.connect if connecting via TLS
         tlsOptions: {}
     };
@@ -113,7 +113,7 @@ function WebSocketClient(config) {
             return this.webSocketVersion;
         }
     });
-    
+
     switch (this.config.webSocketVersion) {
         case 8:
         case 13:
@@ -122,7 +122,7 @@ function WebSocketClient(config) {
             throw new Error("Requested webSocketVersion is not supported. " +
                             "Allowed values are 8 and 13.");
     }
-    
+
     this.readyState = INIT;
 }
 
@@ -138,7 +138,7 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
     }
     this.protocols = protocols;
     this.origin = origin;
-    
+
     if (typeof(requestUrl) === 'string') {
         this.url = url.parse(requestUrl);
     }
@@ -151,9 +151,9 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
     if (!this.url.host) {
         throw new Error("You must specify a full WebSocket URL, including hostname.  Relative URLs are not supported.");
     }
-    
+
     this.secure = (this.url.protocol === 'wss:');
-    
+
     // validate protocol characters:
     this.protocols.forEach(function(protocol, index, array) {
         for (var i=0; i < protocol.length; i ++) {
@@ -173,13 +173,13 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
     if (!this.url.port) {
         this.url.port = defaultPorts[this.url.protocol];
     }
-    
+
     var nonce = new Buffer(16);
     for (var i=0; i < 16; i++) {
         nonce[i] = Math.round(Math.random()*0xFF);
     }
     this.base64nonce = nonce.toString('base64');
-    
+
     var hostHeaderValue = this.url.hostname;
     if ((this.url.protocol === 'ws:' && this.url.port !== '80') ||
         (this.url.protocol === 'wss:' && this.url.port !== '443'))  {
@@ -209,16 +209,16 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
     }
 
     // TODO: Implement extensions
-    
+
     var pathAndQuery = this.url.pathname;
     if (this.url.search) {
         pathAndQuery += this.url.search;
     }
-    
+
     function handleRequestError(error) {
         self.emit('connectFailed', error);
     }
-    
+
     if (isNode0_4_x) {
         // Using old http.createClient interface since the new Agent-based API
         // is buggy in Node 0.4.x.
@@ -246,7 +246,7 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
             agent: false
         };
         if (this.secure) {
-            ['key','passphrase','cert','ca','rejectUnauthorized'].forEach(function(key) {
+            ['key','passphrase','cert','ca','rejectUnauthorized','secureProtocol'].forEach(function(key) {
                 if (self.config.tlsOptions.hasOwnProperty(key)) {
                     requestOptions[key] = self.config.tlsOptions[key];
                 }
@@ -268,7 +268,7 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
     else {
         throw new Error("Unsupported Node version " + process.version);
     }
-    
+
     req.on('response', function(response) {
         var headerDumpParts = [];
         for (var headerName in response.headers) {
@@ -286,7 +286,7 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
 
 WebSocketClient.prototype.validateHandshake = function() {
     var headers = this.response.headers;
-    
+
     if (this.protocols.length > 0) {
         this.protocol = headers['sec-websocket-protocol'];
         if (this.protocol) {
@@ -300,33 +300,33 @@ WebSocketClient.prototype.validateHandshake = function() {
             return;
         }
     }
-    
+
     if (!(headers['connection'] && headers['connection'].toLocaleLowerCase() === 'upgrade')) {
         this.failHandshake("Expected a Connection: Upgrade header from the server");
         return;
     }
-    
+
     if (!(headers['upgrade'] && headers['upgrade'].toLocaleLowerCase() === 'websocket')) {
         this.failHandshake("Expected an Upgrade: websocket header from the server");
         return;
     }
-    
+
     var sha1 = crypto.createHash('sha1');
     sha1.update(this.base64nonce + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
     var expectedKey = sha1.digest('base64');
-    
+
     if (!headers['sec-websocket-accept']) {
         this.failHandshake("Expected Sec-WebSocket-Accept header from server");
         return;
     }
-    
+
     if (!(headers['sec-websocket-accept'] === expectedKey)) {
         this.failHandshake("Sec-WebSocket-Accept header from server didn't match expected value of " + expectedKey);
         return;
     }
-    
+
     // TODO: Support extensions
-    
+
     this.succeedHandshake();
 };
 
@@ -339,7 +339,7 @@ WebSocketClient.prototype.failHandshake = function(errorDescription) {
 
 WebSocketClient.prototype.succeedHandshake = function() {
     var connection = new WebSocketConnection(this.socket, [], this.protocol, true, this.config);
-    
+
     connection.webSocketVersion = this.config.webSocketVersion;
     // Deprecated websocketVersion (proper casing...)
     Object.defineProperty(connection, "websocketVersion", {
@@ -348,7 +348,7 @@ WebSocketClient.prototype.succeedHandshake = function() {
             return this.webSocketVersion;
         }
     });
-    
+
     this.emit('connect', connection);
     if (this.firstDataChunk.length > 0) {
         connection.handleSocketData(this.firstDataChunk);


### PR DESCRIPTION
Adding support for the `secureProtocol` TLS option. This allows one to set the SSL method to use. Without this, if one tries to make a connection using secure WebSockets to a server that only supports SSLv3, the connection will fail with an error message similar to:

```
Connect Error: { [Error: socket hang up] code: 'ECONNRESET', sslError: undefined }
```

This is because by default, Node.js does not enable support for SSLv3 in the TLS options.

**Aside:** I wonder if a better way of allows users to pass through options is to just copy all of the keys from the `config.tlsOptions` object and let Node.js figure out what key are valid/invalid.
