### PR TITLE
add initial HTTP proxy support

### DIFF
--- a/lib/WebSocketClient.js
+++ b/lib/WebSocketClient.js
@@ -129,7 +129,7 @@ function WebSocketClient(config) {
 
 util.inherits(WebSocketClient, EventEmitter);
 
-WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, headers) {
+WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, headers, tunnelingAgent) {
     var self = this;
     if (typeof(protocols) === 'string') {
         if (protocols.length > 0) {
@@ -156,6 +156,12 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
     }
     if (!this.url.host) {
         throw new Error("You must specify a full WebSocket URL, including hostname.  Relative URLs are not supported.");
+    }
+    
+    if(tunnelingAgent) {
+        if(tunnelingAgent.constructor.name != 'TunnelingAgent') {
+            throw new Error("You must specify a valid TunnelingAgent object. See node-tunnel documentation.");
+        }
     }
     
     this.secure = (this.url.protocol === 'wss:');
@@ -231,7 +237,7 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
         method: 'GET',
         path: pathAndQuery,
         headers: reqHeaders,
-        agent: false
+        agent: tunnelingAgent || false
     };
     if (this.secure) {
         ['key','passphrase','cert','ca','rejectUnauthorized'].forEach(function(key) {


### PR DESCRIPTION
I have added some basic support for using the WebSocket client with an HTTP proxy. Developers will pass a `TunnelingAgent` object to `WebSocketClient.prototype.connect`. `TunnelingAgent` is generated with [node-tunnel](https://github.com/koichik/node-tunnel), which does all the proxy work.

Example

``` javascript
var WebSocketClient = require('websocket').client;
var client = new WebSocketClient();
var tunnel = require('tunnel');

var tunnelingAgent = tunnel.httpOverHttp({
  proxy: {
    host: 'proxy.host.com',
    port: 8080
  }
});

client.connect('ws://echo.websocket.org/',null,null,null,tunnelingAgent);
```

While this may seem more complicated than passing a `"http://proxy.host.com:8080"` string argument, I believe this gives developers the flexibility of defining all aspects of `TunnelingAgent`. (It gets complicated if you are dealing with SSL, defined certificates, and authentication.). Developers designing user applications may choose to parse out a string argument to build the `TunnelingAgent` object to fit their needs.

Thoughts?
