### PR TITLE
Add ability to limit websocket's upgrade scope to a particular URL via config

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -145,12 +145,6 @@ WebSocketServer.prototype.mount = function(config) {
             this.config.httpServer.on('upgrade', function( request, socket ) {
                 if(request.url.indexOf(this.config.url) == 0) {
                     this._handlers.upgrade.apply( this._handlers, arguments );
-                } else {
-                    var wsRequest = new WebSocketRequest(socket, request, this.config);
-                    wsRequest.reject(
-                        500,
-                        'Bad request'
-                    );
                 }
             }.bind( this ) );
         } catch( err ) {


### PR DESCRIPTION
This may seem odd, but in some cases, we need the ability to use this library for node-client to node-server web socket communication while using socket.io for browser client to node server. Socket.io limits the requests it considers for upgrade based on path. This change makes it possible to do the same with this library on an optional basis. I hope you'll consider it. Let me know if there are any changes I need to make.
