### PR TITLE
WebSocketClient: ability to specify http/socket options on connect

### DIFF
--- a/lib/WebSocketClient.js
+++ b/lib/WebSocketClient.js
@@ -129,7 +129,7 @@ function WebSocketClient(config) {
 
 util.inherits(WebSocketClient, EventEmitter);
 
-WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, headers) {
+WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, headers, options) {
     var self = this;
     if (typeof(protocols) === 'string') {
         if (protocols.length > 0) {
@@ -225,14 +225,16 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
         self.emit('connectFailed', error);
     }
     
-    var requestOptions = {
+    var requestOptions = {};
+    extend(requestOptions, options || {});
+    extend(requestOptions, {
         hostname: this.url.hostname,
         port: this.url.port,
         method: 'GET',
         path: pathAndQuery,
         headers: reqHeaders,
         agent: false
-    };
+    });
     if (this.secure) {
         ['key','passphrase','cert','ca','rejectUnauthorized'].forEach(function(key) {
             if (self.config.tlsOptions.hasOwnProperty(key)) {


### PR DESCRIPTION
Sometimes, it is necessary to choose the local port and local address to bind the TCP socket to. http.request has an option object that it forwards to net.createConnection. Is it logical that the websocket module also give access to this option object.
