### PR TITLE
Permanent heavy load

### DIFF
--- a/lib/WebSocketConnection.js
+++ b/lib/WebSocketConnection.js
@@ -37,8 +37,6 @@ function WebSocketConnection(socket, extensions, protocol, maskOutgoingPackets, 
     this.remoteAddress = socket.remoteAddress;
     this.closeReasonCode = -1;
     this.closeDescription = null;
-    this.assemblingFrames = false;
-    this.assembleFramesHandler = this.assembleFrames.bind(this);
     
     // We have to mask outgoing packets if we're acting as a WebSocket client.
     this.maskOutgoingPackets = maskOutgoingPackets;
@@ -88,6 +86,9 @@ function WebSocketConnection(socket, extensions, protocol, maskOutgoingPackets, 
     this.outputPaused = false;
     this.outgoingFrameQueueHandler = this.processOutgoingFrameQueue.bind(this);
     this.bytesWaitingToFlush = 0;
+
+    this.inputPaused = false;
+    this.pendingDigestCallbacks = 0;
     
     this._closeTimerHandler = this.handleCloseTimer.bind(this);
     
@@ -175,6 +176,24 @@ function validateReceivedCloseReason(code) {
 
 util.inherits(WebSocketConnection, EventEmitter);
 
+WebSocketConnection.prototype._onDigestCallback = function() {
+    if(this.pendingDigestCallbacks < 0) {
+        this.pendingDigestCallbacks = 0;
+    }
+    this.pendingDigestCallbacks++;
+    //console.log('+: ' + this.pendingDigestCallbacks);
+};
+
+WebSocketConnection.prototype._offDigestCallback = function() {
+    if(--this.pendingDigestCallbacks === 0) {
+        this.handleSocketData();
+    }
+    if(this.pendingDigestCallbacks < 0) {
+        this.pendingDigestCallbacks = 0;
+    }
+    //console.log('-:' + this.pendingDigestCallbacks);
+};
+
 // set or reset the keepalive timer when data is received.
 WebSocketConnection.prototype.setKeepaliveTimer = function() {
     if (!this.config.keepalive) { return; }
@@ -217,29 +236,28 @@ WebSocketConnection.prototype.handleGracePeriodTimer = function() {
 };
 
 WebSocketConnection.prototype.handleSocketData = function(data) {
-    // Add received data to our bufferList, which efficiently holds received
-    // data chunks in a linked list of Buffer objects.
-    this.bufferList.write(data);
 
-    if (!this.assemblingFrames) {
-        this.assembleFrames();
+    var self = this;
+
+    if(!self.bufferList) {
+        return;
     }
-};
 
-WebSocketConnection.prototype.assembleFrames = function() {
-    // Reset the keepalive timer when receiving data of any kind.
-    this.setKeepaliveTimer();
+    if(typeof(data) !== "undefined") {
+        // Reset the keepalive timer when receiving data of any kind.
+        this.setKeepaliveTimer();
+    
+        // Add received data to our bufferList, which efficiently holds received
+        // data chunks in a linked list of Buffer objects.
+        this.bufferList.write(data);
+    }
 
-    var assemblyStarted = Date.now();
-    do {
-        // currentFrame.addData returns true if all data necessary to parse
-        // the frame was available.  It returns false if we are waiting for
-        // more data to come in on the wire.
-        if (!this.connected || !this.currentFrame.addData(this.bufferList)) {
-            this.assemblingFrames = false;
-            break;
-        }
-        this.assemblingFrames = true;
+    var bufferLength = this.bufferList.length;
+    
+    // currentFrame.addData returns true if all data necessary to parse
+    // the frame was available.  It returns false if we are waiting for
+    // more data to come in on the wire.
+    while (this.connected && this.currentFrame.addData(this.bufferList)) {
 
         // Handle possible parsing errors
         if (this.currentFrame.protocolError) {
@@ -247,13 +265,13 @@ WebSocketConnection.prototype.assembleFrames = function() {
             this.drop(WebSocketConnection.CLOSE_REASON_PROTOCOL_ERROR, this.currentFrame.dropReason);
             return;
         }
-        else if (this.currentFrame.frameTooLarge) {
+
+        if (this.currentFrame.frameTooLarge) {
             this.drop(WebSocketConnection.CLOSE_REASON_MESSAGE_TOO_BIG, this.currentFrame.dropReason);
             return;
         }
-
-        // For now since we don't support extensions, all RSV bits are
-        // illegal.
+        
+        // For now since we don't support extensions, all RSV bits are illegal
         if (this.currentFrame.rsv1 || this.currentFrame.rsv2 || this.currentFrame.rsv3) {
             this.drop(WebSocketConnection.CLOSE_REASON_PROTOCOL_ERROR,
                       "Unsupported usage of rsv bits without negotiated extension.");
@@ -265,23 +283,24 @@ WebSocketConnection.prototype.assembleFrames = function() {
         }
         this.processFrame(this.currentFrame);
         this.currentFrame = new WebSocketFrame(this.maskBytes, this.frameHeader, this.config);
-    } while (Date.now() - assemblyStarted < this.config.messageBlockingTime);
 
-    if (this.assemblingFrames) {
-        if (this.bufferList.length > this.config.receiveBufferSize) {
-            this.socket.pause();
+        if(bufferLength - this.bufferList.length > this.config.receiveBufferSize) {
+            break;
         }
-        else {
-            this.socket.resume();
-        }
-
-        // Blocking time limit was exceeded.  Handle the next frame after other
-        // clients have a chance to run.
-        setTimeout(this.assembleFramesHandler, 0);
     }
-    else {
-        // Always resume the socket if we don't have a full frame.
-        this.socket.resume();
+
+    if(this.pendingDigestCallbacks > 0) {
+        if(!this.inputPaused) {
+            //console.log('socket paused');
+            this.socket.pause();
+            this.inputPaused = true;
+        }
+    }else{
+        if(this.inputPaused) {
+            //console.log('socket resumed');
+            this.socket.resume();
+            this.inputPaused = false;
+        }
     }
 };
 
@@ -345,16 +364,16 @@ WebSocketConnection.prototype.drop = function(reasonCode, description, skipClose
     if (typeof(reasonCode) !== 'number') {
         reasonCode = WebSocketConnection.CLOSE_REASON_PROTOCOL_ERROR;
     }
-    // var logText = "WebSocket: Dropping Connection. Code: " + reasonCode.toString(10);
+    var logText = "WebSocket: Dropping Connection. Code: " + reasonCode.toString(10);
     
     if (typeof(description) !== 'string') {
         // If no description is provided, try to look one up based on the
         // specified reasonCode.
         description = WebSocketConnection.CLOSE_DESCRIPTIONS[reasonCode];
     }
-    // if (description) {
-    //     logText += (" - " + description);
-    // }
+    if (description) {
+        logText += (" - " + description);
+    }
     // console.error((new Date()) + " " + logText);
     
     this.closeReasonCode = reasonCode;
@@ -400,6 +419,7 @@ WebSocketConnection.prototype.handleCloseTimer = function() {
 WebSocketConnection.prototype.processFrame = function(frame) {
     var i;
     var message;
+    var self = this;
     
     // Any non-control opcode besides 0x00 (continuation) received in the
     // middle of a fragmented message is illegal.
@@ -415,9 +435,13 @@ WebSocketConnection.prototype.processFrame = function(frame) {
             if (this.assembleFragments) {
                 if (frame.fin) {
                     // Complete single-frame message received
-                    this.emit('message', {
-                        type: 'binary',
-                        binaryData: frame.binaryPayload
+                    this._onDigestCallback();
+                    process.nextTick(function() {
+                        self.emit('message', {
+                            type: 'binary',
+                            binaryData: frame.binaryPayload
+                        },self._onDigestCallback.bind(self),self._offDigestCallback.bind(self));
+                        self._offDigestCallback();
                     });
                 }
                 else {
@@ -436,9 +460,13 @@ WebSocketConnection.prototype.processFrame = function(frame) {
                         return;
                     }
                     // Complete single-frame message received
-                    this.emit('message', {
-                        type: 'utf8',
-                        utf8Data: frame.binaryPayload.toString('utf8')
+                    this._onDigestCallback();
+                    process.nextTick(function() {
+                        self.emit('message', {
+                            type: 'utf8',
+                            utf8Data: frame.binaryPayload.toString('utf8')
+                        },self._onDigestCallback.bind(self),self._offDigestCallback.bind(self));
+                        self._offDigestCallback();
                     });
                 }
                 else {
@@ -479,9 +507,13 @@ WebSocketConnection.prototype.processFrame = function(frame) {
                 
                     switch (this.frameQueue[0].opcode) {
                         case 0x02: // WebSocketOpcode.BINARY_FRAME
-                            this.emit('message', {
-                                type: 'binary',
-                                binaryData: binaryPayload
+                            this._onDigestCallback();
+                            process.nextTick(function() {
+                                self.emit('message', {
+                                    type: 'binary',
+                                    binaryData: binaryPayload
+                                },self._onDigestCallback.bind(self),self._offDigestCallback.bind(self));
+                                self._offDigestCallback();
                             });
                             break;
                         case 0x01: // WebSocketOpcode.TEXT_FRAME
@@ -490,9 +522,13 @@ WebSocketConnection.prototype.processFrame = function(frame) {
                                           "Invalid UTF-8 Data Received");
                                 return;
                             }
-                            this.emit('message', {
-                                type: 'utf8',
-                                utf8Data: binaryPayload.toString('utf8')
+                            this._onDigestCallback();
+                            process.nextTick(function() {
+                                self.emit('message', {
+                                    type: 'utf8',
+                                    utf8Data: binaryPayload.toString('utf8')
+                                },self._onDigestCallback.bind(self),self._offDigestCallback.bind(self));
+                                self._offDigestCallback();
                             });
                             break;
                         default:


### PR DESCRIPTION
Under permanent heavy load we experienced uncontrolled socket reading resulting in server crush (exceeding memory limit). Due to our specific, incoming data was huge in amount. Every tick server was just busy reading from incoming socket, .receiveBufferSize and .messageBlockingTime were not able to control the situation. Also, sometimes our processing of incoming messages could be completed at current tick, and sometimes it was not so. 

The proposed changes allows to keep server running under extremely heavy load stable. 

In case the incoming message can be processed at current tick nothing has to be changed in user code. In case there are few tick required - emitted event also contains 2nd and 3rd arguments as functions `pause` and `resume`. When it is necessary to wait for multiple operations to be completed - it is just safe to call `pause` several times one time per async operation and wait while all `resume` will alarm in operations callbacks.

Our current production uses node-0.8, the proposed fix was tested under 0.8 only. I guess, under node 0.10 the semantics of .nextTick changed, and probably .processFrame has to be rewritten with setImmediate to function properly.

Thanks for awesome library! :)
