### PR TITLE
Ability to handle non-101 HTTP Responses

### DIFF
--- a/lib/WebSocketClient.js
+++ b/lib/WebSocketClient.js
@@ -254,16 +254,24 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
     req.on('error', handleRequestError);
     
     req.on('response', function(response) {
-        var headerDumpParts = [];
-        for (var headerName in response.headers) {
-            headerDumpParts.push(headerName + ": " + response.headers[headerName]);
+        if (EventEmitter.listenerCount(self, 'httpResponse') > 0) {
+            self.emit('httpResponse', response, self);
+            if (response.socket) {
+                response.socket.end();
+            }
         }
-        self.failHandshake(
-            "Server responded with a non-101 status: " +
-            response.statusCode +
-            "\nResponse Headers Follow:\n" +
-            headerDumpParts.join('\n') + "\n"
-        );
+        else {
+            var headerDumpParts = [];
+            for (var headerName in response.headers) {
+                headerDumpParts.push(headerName + ": " + response.headers[headerName]);
+            }
+            self.failHandshake(
+                "Server responded with a non-101 status: " +
+                response.statusCode +
+                "\nResponse Headers Follow:\n" +
+                headerDumpParts.join('\n') + "\n"
+            );
+        }
     });
     req.end();
 };


### PR DESCRIPTION
Add the ability to handle non-upgrade responses (401, trusted 30x redirects, retries on 503, etc.).

If an on 'httpResponse' listener is present, pass the http response to the listener. Otherwise, fall back on the current behavior.
