### PR TITLE
"tlsOptions" are passed directly now.

### DIFF
--- a/lib/WebSocketClient.js
+++ b/lib/WebSocketClient.js
@@ -109,7 +109,7 @@ function WebSocketClient(config) {
         messageBlockingTime: 1,
 
         // Options to pass to https.connect if connecting via TLS
-        tlsOptions: {}
+        tlsOptions: config.tlsOptions || {}
     };
     if (config) {
         extend(this.config, config);
@@ -234,11 +234,11 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
         agent: false
     };
     if (this.secure) {
-        ['key','passphrase','cert','ca','rejectUnauthorized'].forEach(function(key) {
-            if (self.config.tlsOptions.hasOwnProperty(key)) {
-                requestOptions[key] = self.config.tlsOptions[key];
-            }
-        });
+       for (var key in self.config.tlsOptions) {
+           if (self.config.tlsOptions.hasOwnProperty(key)) {
+               requestOptions[key] = self.config.tlsOptions[key];
+           }
+       }
         var req = https.request(requestOptions);
     }
     else {


### PR DESCRIPTION
Issue referenced here: https://github.com/Worlize/WebSocket-Node/issues/112
