### PR TITLE
Emit the CloseEvent object on connection close.

### DIFF
--- a/lib/CloseEvent.js
+++ b/lib/CloseEvent.js
@@ -1,0 +1,7 @@
+module.exports = CloseEvent;
+
+function CloseEvent(wasClean, code, reason) {
+  this.wasClean = wasClean || false;
+  this.code = code || 0;
+  this.reason = reason || "";
+}

--- a/lib/WebSocketConnection.js
+++ b/lib/WebSocketConnection.js
@@ -21,6 +21,7 @@ var WebSocketFrame = require('./WebSocketFrame');
 var BufferList = require('../vendor/FastBufferList');
 var Constants = require('./Constants');
 var Validation = require('./Validation').Validation;
+var CloseEvent = require('./CloseEvent');
 
 const STATE_OPEN = "open";
 const STATE_CLOSING = "closing";
@@ -304,7 +305,6 @@ WebSocketConnection.prototype.handleSocketEnd = function() {
 
 WebSocketConnection.prototype.handleSocketClose = function(hadError) {
     // console.log((new Date()) + " - Socket Close");
-    this.socketHadError = hadError;
     this.connected = false;
     this.state = STATE_CLOSED;
     // If closeReasonCode is still set to -1 at this point then we must
@@ -316,7 +316,8 @@ WebSocketConnection.prototype.handleSocketClose = function(hadError) {
     if (!this.closeEventEmitted) {
         this.closeEventEmitted = true;
         // console.log((new Date()) + " - Emitting WebSocketConnection close event");
-        this.emit('close', this.closeReasonCode, this.closeDescription);
+        var closeEvent = new CloseEvent(!hadError, this.closeReasonCode, this.closeDescription);
+        this.emit('close', closeEvent);
     }
     this.clearCloseTimer();
     if (this._keepaliveTimeoutID) {
@@ -368,7 +369,8 @@ WebSocketConnection.prototype.drop = function(reasonCode, description, skipClose
     this.connected = false;
     this.state = STATE_CLOSED;
     this.closeEventEmitted = true;
-    this.emit('close', reasonCode, description);
+    var closeEvent = new CloseEvent(false, this.closeReasonCode, this.closeDescription);
+    this.emit('close', closeEvent);
     this.socket.destroy();
 };
 

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -216,8 +216,8 @@ WebSocketServer.prototype.handleUpgrade = function(request, socket, head) {
 
 WebSocketServer.prototype.handleRequestAccepted = function(connection) {
     var self = this;
-    connection.once('close', function(closeReason, description) {
-        self.handleConnectionClose(connection, closeReason, description);
+    connection.once('close', function(closeEvent) {
+        self.handleConnectionClose(connection, closeEvent.code, closeEvent.reason);
     });
     this.connections.push(connection);
     this.emit('connect', connection);


### PR DESCRIPTION
Fixes #130: as specified in [The WebSocket API](http://www.w3.org/TR/websockets/#closeWebSocket) when _the WebSocket connection is closed_ an event that uses the [CloseEvent](http://www.w3.org/TR/websockets/#closeevent) interface has to be created.
