### PR TITLE
W3C WebSocket API

### DIFF
--- a/docs/W3CWebSocket.md
+++ b/docs/W3CWebSocket.md
@@ -1,0 +1,33 @@
+W3CWebSocket
+============
+
+* [Constructor](#constructor)
+* [Limitations](#limitations)
+
+`var W3CWebSocket = require('websocket').w3cwebsocket`
+
+Implementation of the [W3C WebSocket API](http://www.w3.org/TR/websockets/) for browsers.
+
+The exposed class lets the developer use the browser WebSocket API in Node.
+
+
+Constructor
+-----------
+
+```javascript
+new WebSocket(requestUrl, requestedProtocols, [[[[origin], headers], requestOptions], clientConfig])
+```
+
+**clientConfig** is the parameter of the [WebSocketClient](./WebSocketClient.md) constructor.
+
+**requestUrl**, **requestedProtocols**, **origin**, **headers** and **requestOptions** are parameters to be used in the `connect()` method of [WebSocketClient](./WebSocketClient.md).
+
+This constructor API makes it possible to use the W3C API and "browserify" the Node application into a valid browser library.
+
+
+Limitations
+-----------
+
+* `bufferedAmount` attribute is always 0.
+* `binaryType` is "arraybuffer" by default given that "blob" is not supported (Node does not implement the `Blob` class).
+* `send()` method allows arguments of type `DOMString`, `ArrayBuffer`, `ArrayBufferView` (`Int8Array`, etc) or Node `Buffer`, but does not allow `Blob`.

--- a/lib/W3CWebSocket.js
+++ b/lib/W3CWebSocket.js
@@ -1,0 +1,263 @@
+/************************************************************************
+ *  Copyright 2010-2014 Worlize Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ***********************************************************************/
+
+var WebSocketClient = require('./WebSocketClient');
+var toBuffer = require('typedarray-to-buffer');
+
+
+const CONNECTING = 0;
+const OPEN = 1;
+const CLOSING = 2;
+const CLOSED = 3;
+
+
+function WebSocket(url, protocols, origin, headers, requestOptions, clientConfig) {
+    // Sanitize clientConfig.
+    clientConfig = clientConfig || {};
+    clientConfig.assembleFragments = true;  // Required in the W3C API.
+
+    // W3C attributes and listeners.
+    this._listeners = {
+        onopen: undefined,
+        onerror: undefined,
+        onclose: undefined,
+        onmessage: undefined
+    };
+    this._url = url;
+    this._readyState = CONNECTING;
+    this._protocol = undefined;
+    this._extensions = '';
+    this._bufferedAmount = 0;  // Hack, always 0.
+    this._binaryType = 'arraybuffer';  // TODO: Should be 'blob' by default, but Node has no Blob.
+
+    // The WebSocketConnection instance.
+    this._connection = undefined;
+
+    // WebSocketClient instance.
+    this._client = new WebSocketClient(clientConfig);
+
+    this._client.on('connect', onConnect.bind(this));
+    this._client.on('connectFailed', onConnectFailed.bind(this));
+
+    this._client.connect(url, protocols, origin, headers, requestOptions);
+}
+
+
+// Expose W3C listener setters/getters.
+['onopen', 'onerror', 'onclose', 'onmessage'].forEach(function(method) {
+    Object.defineProperty(WebSocket.prototype, method, {
+        get: function() {
+            return this._listeners[method];
+        },
+        set: function(listener) {
+            if (typeof listener === 'function') {
+                this._listeners[method] = listener;
+            }
+            else {
+                this._listeners[method] = undefined;
+            }
+        }
+    });
+});
+
+
+// Expose W3C read only attributes.
+Object.defineProperties(WebSocket.prototype, {
+    url:            { get: function() { return this._url;            } },
+    readyState:     { get: function() { return this._readyState;     } },
+    protocol:       { get: function() { return this._protocol;       } },
+    extensions:     { get: function() { return this._extensions;     } },
+    bufferedAmount: { get: function() { return this._bufferedAmount; } }
+});
+
+
+// Expose W3C write/read attributes.
+Object.defineProperties(WebSocket.prototype, {
+    binaryType: {
+        get: function() {
+            return this._binaryType;
+        },
+        set: function(type) {
+            // TODO: Just 'arraybuffer' supported.
+            if (type !== 'arraybuffer') {
+                throw new SyntaxError('just "blob" type allowed for "binaryType" attribute');
+            }
+            this._binaryType = type;
+        }
+    }
+});
+
+
+// Expose W3C readyState constants.
+[['CONNECTING',CONNECTING], ['OPEN',OPEN], ['CLOSING',CLOSING], ['CLOSED',CLOSED]].forEach(function(name, value) {
+    Object.defineProperty(WebSocket.prototype, name, {
+        get: function() { return value; }
+    });
+});
+
+
+WebSocket.prototype.send = function(data) {
+    if (this._readyState !== OPEN) {
+        throw new Error('cannot call send() while not connected');
+    }
+
+    // Text.
+    if (typeof data === 'string' || data instanceof String) {
+        this._connection.sendUTF(data);
+    }
+    // Binary.
+    else {
+        // Node Buffer.
+        if (data instanceof Buffer) {
+            this._connection.sendBytes(data);
+        }
+        // If ArrayBuffer or ArrayBufferView convert it to Node Buffer.
+        else if (data.byteLength || data.byteLength === 0) {
+            data = toBuffer(data);
+            this._connection.sendBytes(data);
+        }
+        else {
+            throw new Error('unknown binary data:', data);
+        }
+    }
+};
+
+
+WebSocket.prototype.close = function() {
+    switch(this._readyState) {
+        case CONNECTING:
+            // TODO: We don't have the WebSocketConnection instance yet so no
+            // way to close the TCP connection.
+            // Artificially invoke the onConnectFailed event.
+            onConnectFailed.call(this);
+            // And close if it connects after a while.
+            this._client.on('connect', function(connection) {
+                connection.close();
+            });
+            break;
+        case OPEN:
+            this._readyState = CLOSING;
+            this._connection.close();
+        case CLOSING:
+        case CLOSED:
+            break;
+    }
+};
+
+
+/**
+ * Private API.
+ */
+
+
+function onConnect(connection) {
+    this._readyState = OPEN;
+    this._connection = connection;
+    this._protocol = connection.protocol;
+    this._extensions = connection.extensions;
+
+    this._connection.on('close', onClose.bind(this));
+    this._connection.on('message', onMessage.bind(this));
+
+    callListener.call(this, 'onopen', new OpenEvent(this));
+}
+
+
+function onConnectFailed() {
+    destroy.call(this);
+    this._readyState = CLOSED;
+
+    // Emit 'close' after 'error' even if 'error' listener throws.
+    global.setTimeout(function() {
+        callListener.call(this, 'onclose', new CloseEvent(this, 1006, 'connection failed'));
+    }.bind(this));
+    callListener.call(this, 'onerror', new ErrorEvent(this));
+}
+
+
+function onClose(code, reason) {
+    destroy.call(this);
+    this._readyState = CLOSED;
+
+    callListener.call(this, 'onclose', new CloseEvent(this, code, reason || ''));
+}
+
+
+function onMessage(message) {
+    if (message.utf8Data) {
+        callListener.call(this, 'onmessage', new MessageEvent(this, message.utf8Data));
+    }
+    else if (message.binaryData) {
+        // Must convert from Node Buffer to ArrayBuffer.
+        // TODO: or to a Blob (which does not exist in Node!).
+        if (this.binaryType === 'arraybuffer') {
+            var buffer = message.binaryData;
+            var arraybuffer = new ArrayBuffer(buffer.length);
+            var view = new Uint8Array(arraybuffer);
+            for (var i=0, len=buffer.length; i<len; ++i) {
+                view[i] = buffer[i];
+            }
+            callListener.call(this, 'onmessage', new MessageEvent(this, arraybuffer));
+        }
+    }
+}
+
+
+function destroy() {
+    this._client.removeAllListeners();
+    if (this._connection) {
+        this._connection.removeAllListeners();
+    }
+}
+
+
+function callListener(method, event) {
+    var listener = this._listeners[method];
+    if (listener) {
+        listener(event);
+    }
+}
+
+
+function OpenEvent(target) {
+    this.type = 'open';
+    this.target = target;
+}
+
+
+function ErrorEvent(target) {
+    this.type = 'error';
+    this.target = target;
+}
+
+
+function CloseEvent(target, code, reason) {
+    this.type = 'close';
+    this.target = target;
+    this.code = code;
+    this.reason = reason;
+    this.wasClean = (typeof code === 'undefined' || code === 1000);
+}
+
+
+function MessageEvent(target, data) {
+    this.type = 'message';
+    this.target = target;
+    this.data = data;
+}
+
+
+module.exports = WebSocket;

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,14 +1,16 @@
-function NotSupported() {
-    throw new Error("Sorry, WebSocket-Node isn't supported in the browser at this time.");
-}
+var global = (function() { return this; })();
 
+
+/**
+ * W3CWebSocket constructor.
+ */
+var W3CWebSocket = global.WebSocket || global.MozWebSocket;
+
+
+/**
+ * Module exports.
+ */
 module.exports = {
-    "server"     : NotSupported,
-    "client"     : NotSupported,
-    "router"     : NotSupported,
-    "frame"      : NotSupported,
-    "request"    : NotSupported,
-    "connection" : NotSupported,
-    "deprecation": NotSupported,
-    "version"    : require('./version')
+    'w3cwebsocket' : W3CWebSocket ? W3CWebSocket : null,
+    'version'      : require('./version')
 };

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -1,10 +1,11 @@
 module.exports = {
-    "server"     : require('./WebSocketServer'),
-    "client"     : require('./WebSocketClient'),
-    "router"     : require('./WebSocketRouter'),
-    "frame"      : require('./WebSocketFrame'),
-    "request"    : require('./WebSocketRequest'),
-    "connection" : require('./WebSocketConnection'),
-    "deprecation": require('./Deprecation'),
-    "version"    : require('./version')
+    'server'       : require('./WebSocketServer'),
+    'client'       : require('./WebSocketClient'),
+    'router'       : require('./WebSocketRouter'),
+    'frame'        : require('./WebSocketFrame'),
+    'request'      : require('./WebSocketRequest'),
+    'connection'   : require('./WebSocketConnection'),
+    'w3cwebsocket' : require('./W3CWebSocket'),
+    'deprecation'  : require('./Deprecation'),
+    'version'      : require('./version')
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "debug": "~2.1.0",
-    "nan": "~1.0.0"
+    "nan": "~1.0.0",
+    "typedarray-to-buffer": "^3.0.0"
   },
   "config": {
     "verbose": false


### PR DESCRIPTION
- W3C API implemented.
- lib/browser.js now exports the browser native WebSocket object when available.

...so **websocket** library becomes "browserizable" :)
