### PR TITLE
W3CWebSocket: Simplify native WebSocket factory

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -6,20 +6,23 @@ var nativeWebSocket = _global.WebSocket || _global.MozWebSocket;
  * Expose a W3C WebSocket class with just one or two arguments.
  */
 function W3CWebSocket(uri, protocols) {
-	var instance;
+	var native_instance;
 
 	if (protocols) {
-		instance = new nativeWebSocket(uri, protocols);
+		native_instance = new nativeWebSocket(uri, protocols);
 	}
 	else {
-		instance = new nativeWebSocket(uri);
+		native_instance = new nativeWebSocket(uri);
 	}
 
-	return instance;
-}
-
-if (nativeWebSocket) {
-	W3CWebSocket.prototype = nativeWebSocket.prototype;
+	/**
+	 * 'native_instance' is an instance of nativeWebSocket (the browser's WebSocket
+	 * class). Since it is an Object it will be returned as it is when creating an
+	 * instance of W3CWebSocket via 'new W3CWebSocket()'.
+	 *
+	 * ECMAScript 5: http://bclary.com/2004/11/07/#a-13.2.2
+	 */
+	return native_instance;
 }
 
 


### PR DESCRIPTION
After the conversation in https://github.com/theturtle32/WebSocket-Node/pull/174 I've decided to simplify the native WebSocket wrapper a bit by removing the unnecessary copy of the native `WebSocket` prototype into the wrapper class.
