### PR TITLE
Allow toBuffer to work with empty data

### DIFF
--- a/lib/WebSocketFrame.js
+++ b/lib/WebSocketFrame.js
@@ -214,6 +214,7 @@ WebSocketFrame.prototype.toBuffer = function(nullMask) {
         this.length = data.length;
     }
     else {
+        data = new Buffer(0);
         this.length = 0;
     }
 


### PR DESCRIPTION
I was seeing this error:
```
TypeError: Cannot call method 'copy' of undefined
    at WebSocketFrame.toBuffer (/srv/http/myapp/node_modules/websocket/lib/WebSocketFrame.js:266:14)
    at WebSocketConnection.sendFrame (/srv/http/myapp/node_modules/websocket/lib/WebSocketConnection.js:821:43)
    at WebSocketConnection.ping (/srv/http/myapp/node_modules/websocket/lib/WebSocketConnection.js:726:10)
    at WebSocketConnection.handleKeepaliveTimer (/srv/http/myapp/node_modules/websocket/lib/WebSocketConnection.js:217:10)
    at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)
```
I investigated only as far as to see that making sure `data` is set to a buffer prevents the error from occurring.