### PR TITLE
Revert "adding keepaliveGracePeriod option"

### DIFF
--- a/docs/WebSocketClient.md
+++ b/docs/WebSocketClient.md
@@ -42,9 +42,6 @@ If true, fragmented messages will be automatically assembled and the full messag
 **closeTimeout** - uint - *Default: 5000*  
 The number of milliseconds to wait after sending a close frame for an acknowledgement to come back before giving up and just closing the socket.
 
-**keepaliveGracePeriod** - - *Default: 10000*
-The number of milliseconds to wait after sending a keepalive ping before closing the connection if the connected peer does not respond. Ignored if keepalive is false.
-
 **tlsOptions** - object - *Default: {}*  
 Options to pass to `https.request` if connecting via TLS.  See [Node's HTTPS documentation](http://nodejs.org/api/https.html#https_https_request_options_callback)
 


### PR DESCRIPTION
Reverts theturtle32/WebSocket-Node#197

keepaliveGracePeriod is actually not relevant to the client. It's a server-only configuration option.