### PR TITLE
Support for browserify-lite

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,5 +1,6 @@
 var _global = (function() { return this; })();
 var nativeWebSocket = _global.WebSocket || _global.MozWebSocket;
+var websocket_version = require('./version');
 
 
 /**
@@ -31,5 +32,5 @@ function W3CWebSocket(uri, protocols) {
  */
 module.exports = {
     'w3cwebsocket' : nativeWebSocket ? W3CWebSocket : null,
-    'version'      : require('./version')
+    'version'      : websocket_version
 };


### PR DESCRIPTION
browserify-lite only recognizes require() statements outside of all braces.