### PR TITLE
Expose events to facilitate manual ping/pong handling and tracking

### DIFF
--- a/docs/WebSocketConnection.md
+++ b/docs/WebSocketConnection.md
@@ -88,7 +88,7 @@ Sends a ping frame to the remote peer.  `data` can be a Node `Buffer` or any obj
 
 ###pong(buffer)
 
-Sends a pong frame to the remote peer.  Pong frames may be sent unsolicited and such pong frames will trigger no action on the receiving peer.  Pong frames sent in response to a ping frame must mirror the payload data of the ping frame exactly.  The `WebSocketConnection` object handles this internally for you, so there should be no need to use this method to respond to pings.  Pong frames must not exceed 125 bytes in length.
+Sends a pong frame to the remote peer.  Pong frames may be sent unsolicited and such pong frames will trigger no action on the receiving peer.  Pong frames sent in response to a ping frame must mirror the payload data of the ping frame exactly.  The `WebSocketConnection` object handles this internally for you, so there should be no need to use this method to respond to pings unless you explicitly cancel() this internal behavior (see ping event below).  Pong frames must not exceed 125 bytes in length.
 
 ###sendFrame(webSocketFrame)
 
@@ -129,3 +129,13 @@ This event is emitted when the connection has been fully closed and the socket i
 `function(error)`
 
 This event is emitted when there has been a socket error.  If this occurs, a `close` event will also be emitted.
+
+###ping
+`function(cancel, data)`
+
+This event is emitted when the connection receives a `ping` from the peer.  `cancel` is a function taking no arguments that when called prevents the WebSocketConnection object from automatically replying with a `pong`. `data` is the binary payload contained in the ping frame.
+
+###pong
+`function(data)`
+
+This event is emitted when the connection receives a `pong` from the peer. `data` is the binary data contained in the pong frame.

--- a/lib/WebSocketConnection.js
+++ b/lib/WebSocketConnection.js
@@ -47,6 +47,17 @@ function WebSocketConnection(socket, extensions, protocol, maskOutgoingPackets, 
     // Superclass Constructor
     EventEmitter.call(this);
 
+    this._pingListenerCount = 0;
+    this.on('newListener', function(ev) {
+        if (ev === 'ping'){
+            this._pingListenerCount++;
+        }
+      }).on('removeListener', function(ev) {
+        if (ev === 'ping') {
+            this._pingListenerCount--;
+        }
+    });
+
     this.config = config;
     this.socket = socket;
     this.protocol = protocol;
@@ -606,10 +617,29 @@ WebSocketConnection.prototype.processFrame = function(frame) {
             break;
         case 0x09: // WebSocketFrame.PING
             this._debug('-- Ping Frame');
-            this.pong(frame.binaryPayload);
+
+            if (this._pingListenerCount > 0) {
+                // logic to emit the ping frame: this is only done when a listener is known to exist
+                // Expose a function allowing the user to override the default ping() behavior
+                var cancelled = false;
+                var cancel = function() { 
+                  cancelled = true; 
+                };
+                this.emit('ping', cancel, frame.binaryPayload);
+
+                // Only send a pong if the client did not indicate that he would like to cancel
+                if (!cancelled) {
+                    this.pong(frame.binaryPayload);
+                }
+            }
+            else {
+                this.pong(frame.binaryPayload);
+            }
+
             break;
         case 0x0A: // WebSocketFrame.PONG
             this._debug('-- Pong Frame');
+            this.emit('pong', frame.binaryPayload);
             break;
         case 0x08: // WebSocketFrame.CONNECTION_CLOSE
             this._debug('-- Close Frame');


### PR DESCRIPTION
Following the advice in #205, this rather trivial pull adds a `ping` and a `pong` event. Both events in their handlers pass in the received binary data. The `ping` event additionally adds `cancel`: a function taking no arguments that prevents the default behavior of the `ping` handler.