### PR TITLE
Adds support for receiving multiple protocols/sub-protocols

### DIFF
--- a/lib/WebSocketRequest.js
+++ b/lib/WebSocketRequest.js
@@ -251,25 +251,27 @@ WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, co
     
     // TODO: Handle extensions
 
-    var protocolFullCase;
-	
-	if (util.isArray(acceptedProtocol)) {
-		for (var i = 0; i < acceptedProtocol.length; i++) {
-			if (this.requestedProtocols.indexOf(acceptedProtocol[i]) !== -1) {
-				acceptedProtocol = acceptedProtocol[i];
-				this.protocol = acceptedProtocol;
-			}
-		}
-	}
-	if (acceptedProtocol) {
-        protocolFullCase = this.protocolFullCaseMap[acceptedProtocol.toLocaleLowerCase()];
-        if (typeof(protocolFullCase) === 'undefined') {
-            protocolFullCase = acceptedProtocol;
+        var protocolFullCase;                                                                                                                                                                             
+                                                                                                                                                                                                      
+        if (util.isArray(acceptedProtocol) || util.isObject(acceptedProtocol)) {                                                                                                                      
+                for (var i = 0; i < acceptedProtocol.length; i++) {                                                                                                                                   
+                        if (this.requestedProtocols.indexOf(acceptedProtocol[i]) !== -1) {                                                                                                            
+                                acceptedProtocol = acceptedProtocol[i];                                                                                                                               
+                                this.protocol = acceptedProtocol;                                                                                                                                     
+                        }                                                                                                                                                                             
+                }                                                                                                                                                                                     
+                if (typeof acceptedProtocol != "string") {                                                                                                                                            
+                        acceptedProtocol = null;                                                                                                                                                      
+                }                                                                                                                                                                                     
+        }                                  
+        if (acceptedProtocol) {
+                protocolFullCase = this.protocolFullCaseMap[acceptedProtocol.toLocaleLowerCase()];
+                if (typeof(protocolFullCase) === 'undefined') {
+                    protocolFullCase = acceptedProtocol;
+                }
+        } else {
+                protocolFullCase = acceptedProtocol;
         }
-    }
-    else {
-        protocolFullCase = acceptedProtocol;
-    }
     this.protocolFullCaseMap = null;
 
     // Create key validation hash

--- a/lib/WebSocketRequest.js
+++ b/lib/WebSocketRequest.js
@@ -252,8 +252,16 @@ WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, co
     // TODO: Handle extensions
 
     var protocolFullCase;
-
-    if (acceptedProtocol) {
+	
+	if (util.isArray(acceptedProtocol)) {
+		for (var i = 0; i < acceptedProtocol.length; i++) {
+			if (this.requestedProtocols.indexOf(acceptedProtocol[i]) !== -1) {
+				acceptedProtocol = acceptedProtocol[i];
+				this.protocol = acceptedProtocol;
+			}
+		}
+	}
+	if (acceptedProtocol) {
         protocolFullCase = this.protocolFullCaseMap[acceptedProtocol.toLocaleLowerCase()];
         if (typeof(protocolFullCase) === 'undefined') {
             protocolFullCase = acceptedProtocol;


### PR DESCRIPTION
I wrote this a while ago but it's still necessary if you ask me, for example:
`new WebSocket("ws://example.com/socket", ['echo','messages']`
https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications
as you can see in those documents specifying multiple protocols using an array should be supported.
My little commit just takes the first protocol in that array and uses that.