### PR TITLE
fix #223 - clear reference to last item in FastBufferList when emptied

### DIFF
--- a/vendor/FastBufferList.js
+++ b/vendor/FastBufferList.js
@@ -152,6 +152,7 @@ function BufferList(opts) {
                 : { buffer : null, next : null }
             ;
         }
+        if (head.buffer === null) last = { next : null, buffer : null };
         self.emit('advance', n);
         return self;
     };


### PR DESCRIPTION
fixes #223 