### PR TITLE
To solve Improve managing of connection on WebSockeClient

### DIFF
--- a/lib/WebSocketClient.js
+++ b/lib/WebSocketClient.js
@@ -327,14 +327,14 @@ WebSocketClient.prototype.failHandshake = function(errorDescription) {
 };
 
 WebSocketClient.prototype.succeedHandshake = function() {
-    var connection = new WebSocketConnection(this.socket, [], this.protocol, true, this.config);
+    this.connection = new WebSocketConnection(this.socket, [], this.protocol, true, this.config);
 
-    connection.webSocketVersion = this.config.webSocketVersion;
-    connection._addSocketEventListeners();
+    this.connection.webSocketVersion = this.config.webSocketVersion;
+    this.connection._addSocketEventListeners();
 
-    this.emit('connect', connection);
+    this.emit('connect', this.connection);
     if (this.firstDataChunk.length > 0) {
-        connection.handleSocketData(this.firstDataChunk);
+        this.connection.handleSocketData(this.firstDataChunk);
     }
     this.firstDataChunk = null;
 };


### PR DESCRIPTION
Inserting a global attribute that represents the **WebSocketConnection** in the **WebSocketClient** we are able to manage the connection at low-level.
This change allow us to disconnect the client from a previous connection with a server, for example we can use piece of code like the follows:

_WebSocketClient.connection.close(reasonCode,description)_
