### PR TITLE
added the wsf protocol

### DIFF
--- a/lib/WebSocketClient.js
+++ b/lib/WebSocketClient.js
@@ -100,7 +100,7 @@ function WebSocketClient(config) {
     }
 
     this._req = null;
-    
+
     switch (this.config.webSocketVersion) {
         case 8:
         case 13:
@@ -111,6 +111,40 @@ function WebSocketClient(config) {
 }
 
 util.inherits(WebSocketClient, EventEmitter);
+
+function handleWsfProtocol(url) {
+  var path = require('path');
+  var fs = require('fs');
+  var parts = url.href.substring("wsf://".length).split(path.sep);
+  var sockName = "/";
+  if (parts[0] == "." || parts[0] == "..") {
+      sockName = "";
+  }
+  var found = false;
+  var sep = "";
+  for (var i = 0; i < parts.length; ++i) {
+    sockName += sep + parts[i];
+    // ugly sync but is this really worth change the hole api
+    var stat = fs.statSync(sockName);
+    try {
+      found = stat && stat.isSocket();
+      if (found) {
+        url.socketPath = sockName;
+        url.host = 'localhost';
+        url.hostname = 'localhost';
+        url.pathname = "kaputt";
+        url.path = '/' + parts.slice(i+1).join('/');
+        break;
+      }
+    } catch (e) {
+        // ignore
+    }
+    sep = path.sep
+  }
+  if (!found) {
+    throw new Error('no socket found in wsf url:' + url.href);
+  }
+}
 
 WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, headers, extraRequestOptions) {
     var self = this;
@@ -136,6 +170,9 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
     }
     if (!this.url.protocol) {
         throw new Error('You must specify a full WebSocket URL, including protocol.');
+    }
+    if (this.url.protocol == "wsf:") {
+      handleWsfProtocol(this.url);
     }
     if (!this.url.host) {
         throw new Error('You must specify a full WebSocket URL, including hostname. Relative URLs are not supported.');
@@ -224,6 +261,7 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
     // These options are always overridden by the library.  The user is not
     // allowed to specify these directly.
     extend(requestOptions, {
+        socketPath: this.url.socketPath,
         hostname: this.url.hostname,
         port: this.url.port,
         method: 'GET',

--- a/lib/WebSocketRequest.js
+++ b/lib/WebSocketRequest.js
@@ -95,13 +95,13 @@ function WebSocketRequest(socket, httpRequest, serverConfig) {
     this.remoteAddress = socket.remoteAddress;
     this.remoteAddresses = [this.remoteAddress];
     this.serverConfig = serverConfig;
-    
+
     // Watch for the underlying TCP socket closing before we call accept
     this._socketIsClosing = false;
     this._socketCloseHandler = this._handleSocketCloseBeforeAccept.bind(this);
     this.socket.on('end', this._socketCloseHandler);
     this.socket.on('close', this._socketCloseHandler);
-    
+
     this._resolved = false;
 }
 
@@ -248,7 +248,7 @@ WebSocketRequest.prototype.parseCookies = function(str) {
 
 WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, cookies) {
     this._verifyResolution();
-    
+
     // TODO: Handle extensions
 
     var protocolFullCase;
@@ -286,7 +286,7 @@ WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, co
         }
         if (this.requestedProtocols.indexOf(acceptedProtocol) === -1) {
             this.reject(500);
-            throw new Error('Specified protocol was not requested by the client.');
+            throw new Error('Specified protocol was not requested by the client:'+acceptedProtocol+":"+this.requestedProtocols);
         }
 
         protocolFullCase = protocolFullCase.replace(headerSanitizeRegExp, '');
@@ -426,21 +426,21 @@ WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, co
     // if (negotiatedExtensions) {
     //     response += 'Sec-WebSocket-Extensions: ' + negotiatedExtensions.join(', ') + '\r\n';
     // }
-    
+
     // Mark the request resolved now so that the user can't call accept or
     // reject a second time.
     this._resolved = true;
     this.emit('requestResolved', this);
-    
+
     response += '\r\n';
 
     var connection = new WebSocketConnection(this.socket, [], acceptedProtocol, false, this.serverConfig);
     connection.webSocketVersion = this.webSocketVersion;
     connection.remoteAddress = this.remoteAddress;
     connection.remoteAddresses = this.remoteAddresses;
-    
+
     var self = this;
-    
+
     if (this._socketIsClosing) {
         // Handle case when the client hangs up before we get a chance to
         // accept the connection and send our side of the opening handshake.
@@ -452,7 +452,7 @@ WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, co
                 cleanupFailedConnection(connection);
                 return;
             }
-            
+
             self._removeSocketCloseListeners();
             connection._addSocketEventListeners();
         });
@@ -464,12 +464,12 @@ WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, co
 
 WebSocketRequest.prototype.reject = function(status, reason, extraHeaders) {
     this._verifyResolution();
-    
+
     // Mark the request resolved now so that the user can't call accept or
     // reject a second time.
     this._resolved = true;
     this.emit('requestResolved', this);
-    
+
     if (typeof(status) !== 'number') {
         status = 403;
     }

--- a/test/unit/fileSockets.js
+++ b/test/unit/fileSockets.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+var test = require('tape');
+var http = require('http');
+var WebSocketServer = require('../../lib/WebSocketServer');
+var WebSocketClient = require('../../lib/WebSocketClient');
+
+
+function serverSide(t, sockFname) {
+  var server = http.createServer((request, response) => {
+    response.writeHead(404);
+    response.end();
+  });
+  server.listen(sockFname, () => { });
+  server.on('error', (e) => {
+    t.assert(true, false, "errors should not happen");
+  });
+
+  var wsServer = new WebSocketServer({ httpServer: server, autoAcceptConnections: false });
+  wsServer.on('request', (request) => {
+    var connection = request.accept('sockfname-protocol', request.origin);
+    connection.on('message', function(message) {
+      //console.log(">>",message);
+      switch (message.utf8Data)  {
+        case "ping" :
+          connection.send("pong");
+          break;
+        case "bye" :
+          connection.close();
+          break;
+      }
+    });
+    connection.on('close', function(reasonCode, description) {
+    });
+  });
+  return server;
+}
+
+function clientSide(t, sockFname, cb) {
+    let client = new WebSocketClient();
+    client.on('connectFailed', (error) => {
+      console.error(error);
+      t.assert(true, false, "errors should not happen");
+    });
+
+    client.on('connect', (connection) => {
+        connection.on('error', (error) => {
+          t.assert(true, false, "errors should not happen");
+        });
+        connection.on('close', function() {
+          t.assert(true, true);
+          cb();
+        });
+        connection.on('message', function(message) {
+          switch (message.utf8Data) {
+            case "pong" :
+              connection.send("bye");
+          }
+        });
+        //console.log("<<ping");
+        connection.send("ping");
+    });
+    if (typeof(sockFname) == "number") {
+      client.connect('ws://localhost:'+sockFname+'/', 'sockfname-protocol');
+    } else {
+      client.connect('wsf://'+sockFname+'/', 'sockfname-protocol');
+    }
+}
+
+function run(t, socket, finCb) {
+  var server = serverSide(t, socket);
+  var i = 0;
+  var cb = function() {
+    //console.log("i="+i)
+    if (i < 10) {
+      ++i;
+      clientSide(t, socket, cb);
+    } else {
+      server.close();
+      finCb && finCb();
+    }
+  }
+  clientSide(t, socket, cb);
+}
+
+test('use wsf to connect over file sockets', function(t) {
+  t.plan(10 + 1);
+  var sock = "./S.test."+process.pid;
+  run(t, sock);
+});
+
+test('use wsf to connect over tcp sockets', function(t) {
+  t.plan(10 + 1);
+  run(t, 4711);
+});


### PR DESCRIPTION
Hi,

i added the wsf protocol to support the websocket to run over 
socket files. 
I still think it is alittle fishy but how you think we should define a 
socketPath in a ws: url.

wsf:///absolute/path/to/socket/
wsf://./relative/path/to/socket/

i did not implemented the pathname of the url function. The pathname 
on wsf protocols is this is set to the "kaputt".

I build a test which tests wsf and ws connections

Thx

Meno
