### PR TITLE
Keepalive timer handling fixed

### DIFF
--- a/lib/WebSocketConnection.js
+++ b/lib/WebSocketConnection.js
@@ -209,7 +209,7 @@ WebSocketConnection.prototype._addSocketEventListeners = function() {
 // set or reset the keepalive timer when data is received.
 WebSocketConnection.prototype.setKeepaliveTimer = function() {
     this._debug('setKeepaliveTimer');
-    if (!this.config.keepalive) { return; }
+    if (!this.config.keepalive  || this.config.useNativeKeepalive) { return; }
     this.clearKeepaliveTimer();
     this.clearGracePeriodTimer();
     this._keepaliveTimeoutID = setTimeout(this._keepaliveTimerHandler, this.config.keepaliveInterval);


### PR DESCRIPTION
Starting from version 6.0.0, node returns an error ("callback" argument must be a function) when using native keepalives because of setTimeout calling with null timer handler.
