### PR TITLE
Remove race condition when server closes connection

### DIFF
--- a/lib/WebSocketConnection.js
+++ b/lib/WebSocketConnection.js
@@ -327,7 +327,8 @@ WebSocketConnection.prototype.processReceivedData = function() {
     // processed.  We use setImmediate here instead of process.nextTick to
     // explicitly indicate that we wish for other I/O to be handled first.
     if (this.bufferList.length > 0) {
-        setImmediateImpl(this.receivedDataHandler);
+        this.receivedDataHandler();
+        //setImmediateImpl(this.receivedDataHandler);
     }
 };
 


### PR DESCRIPTION
When server closes connection right after having sent some frames, those are ignored by the client. Frames are lost because they are processed in a nextTick/setImmediate callback, thus socket close event may arrive before they are actually processed.

Added a test that reproduces the error, on my computer it states that it received only 6 frames. I wonder if that could be computer-dependent so if that does not reproduce, try increasing to `var count = 100;` to something much larger.

The fix proposed here does not look right as it disables something done on purpose, as per the comment above (that's why I just commented out the line and not fixed the now useless bound method, I don't think this will be the real solution). Trying to delay socket end handling leads to socket errors, and I did not find anything better, so at least putting something that makes tests green. Welcome to any idea!