### PR TITLE
Protect against omitted Sec-WebSocket-Protocol

### DIFF
--- a/lib/WebSocketRequest.js
+++ b/lib/WebSocketRequest.js
@@ -284,7 +284,7 @@ WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, co
                 throw new Error('Illegal character "' + String.fromCharCode(character) + '" in subprotocol.');
             }
         }
-        if( this.requestedProtocols.length ) {
+        if (this.requestedProtocols.length) {
             // protocol is optional, but if client uses it, it needs to hear it back.
             if (this.requestedProtocols.indexOf(acceptedProtocol) === -1) {
                 this.reject(500);

--- a/lib/WebSocketRequest.js
+++ b/lib/WebSocketRequest.js
@@ -284,13 +284,16 @@ WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, co
                 throw new Error('Illegal character "' + String.fromCharCode(character) + '" in subprotocol.');
             }
         }
-        if (this.requestedProtocols.indexOf(acceptedProtocol) === -1) {
-            this.reject(500);
-            throw new Error('Specified protocol was not requested by the client.');
-        }
+        if( this.requestedProtocols.length ) {
+            // protocol is optional, but if client uses it, it needs to hear it back.
+            if (this.requestedProtocols.indexOf(acceptedProtocol) === -1) {
+                this.reject(500);
+                throw new Error('Specified protocol was not requested by the client.');
+            }
 
-        protocolFullCase = protocolFullCase.replace(headerSanitizeRegExp, '');
-        response += 'Sec-WebSocket-Protocol: ' + protocolFullCase + '\r\n';
+            protocolFullCase = protocolFullCase.replace(headerSanitizeRegExp, '');
+            response += 'Sec-WebSocket-Protocol: ' + protocolFullCase + '\r\n';
+        }
     }
     this.requestedProtocols = null;
 


### PR DESCRIPTION
https://tools.ietf.org/html/rfc6455
page 17, in 4.1 Client Requirements
```
  10.  The request MAY include a header field with the name
        |Sec-WebSocket-Protocol|.  If present, this value indicates one
        or more comma-separated subprotocol the client wishes to speak,
        ordered by preference.
```
The server should not fail if the client does not specify this field.
---
line 155 protocolString is 'undefined' so requestedProtocols will be empty.