### PR TITLE
Include HTTP status description in case of failure

### DIFF
--- a/lib/WebSocketClient.js
+++ b/lib/WebSocketClient.js
@@ -264,7 +264,7 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
             }
             self.failHandshake(
                 'Server responded with a non-101 status: ' +
-                response.statusCode +
+                response.statusCode + ' ' + response.statusMessage +
                 '\nResponse Headers Follow:\n' +
                 headerDumpParts.join('\n') + '\n'
             );


### PR DESCRIPTION
If the HTTP server responds with a non-101 status code include the status description in the error text.