### PR TITLE
IPV6 address percent sign % device name [node patch needed ~ work aro…

### DIFF
--- a/lib/WebSocketClient.js
+++ b/lib/WebSocketClient.js
@@ -129,7 +129,27 @@ WebSocketClient.prototype.connect = function(requestUrl, protocols, origin, head
     this.origin = origin;
 
     if (typeof(requestUrl) === 'string') {
-        this.url = url.parse(requestUrl);
+        let rUrl;
+        if( requestUrl.indexOf("%") > requestUrl.lastIndexOf(":") ) {
+            let devName = requestUrl.split( /[%\]]/ );
+            if ( devName.length === 3 ) {
+                devName = ( '%' + devName[1] );
+                rUrl = url.parse( requestUrl.replace( devName, '' ) );
+                let parm = rUrl.host;
+                let pos = (parm.length - 1);
+                if ( pos > - 1 ) {
+                    rUrl.host = [ parm.slice( 0, pos ), devName, parm.slice( pos ) ].join( '' );
+                }
+                parm = rUrl.href;
+                pos = parm.indexOf(']');
+                if ( pos > - 1 ) {
+                    rUrl.href = [ parm.slice( 0, pos ), devName, parm.slice( pos ) ].join( '' );
+                }
+                rUrl.hostname += devName;
+            }
+        }
+        else rUrl = url.parse( requestUrl );
+        this.url = rUrl;
     }
     else {
         this.url = requestUrl; // in case an already parsed url is passed in.


### PR DESCRIPTION
…und]

The device name component is extracted temporarily and repaired after the parser runs.
I realize building it out manually is an option but this sense more fool proof.
Take it or leave it but it's there for others if they need or want to be assured IPV6 server to server routing with possible device names is available.
See https://github.com/theturtle32/WebSocket-Node/issues/278
