### PR TITLE
add readyState constants to browser `w3cwebsocket`

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -25,7 +25,13 @@ function W3CWebSocket(uri, protocols) {
 	 */
 	return native_instance;
 }
-
+if (NativeWebSocket) {
+	["CONNECTING", "OPEN", "CLOSING", "CLOSED"].forEach(function(prop) {
+		Object.defineProperty(W3CWebSocket, prop, {
+			get: function() { return NativeWebSocket[prop]; }
+		});
+	});
+}
 
 /**
  * Module exports.


### PR DESCRIPTION
Now the exposed `w3cwebsocket` export mirrors the native WebSocket more closely.
I hit this bug when moving previously native code to use this wrapper, the server-sde code was fine,
but the client-side code failed because `WebSocket.OPEN` was `undefined`.