### PR TITLE
Alternative to find native WebSocket

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,5 +1,9 @@
-var _global = (function() { return this; })();
-var nativeWebSocket = _global.WebSocket || _global.MozWebSocket;
+var isNode = false;
+try {
+    isNode = !!global;
+} catch(e) {}
+
+var NativeWebSocket = isNode ? null : window.WebSocket || window.MozWebSocket;
 var websocket_version = require('./version');
 
 


### PR DESCRIPTION
This patch contains safer way to find native Websocket object. The originial `return this` does not work in our project. Since our js has to work both in node and browser, so it's webpacked. And webpack introduced `use strict`, and prevent use of global `this`.