### PR TITLE
fix: do not use `noAssert`

### DIFF
--- a/lib/BufferUtil.fallback.js
+++ b/lib/BufferUtil.fallback.js
@@ -17,12 +17,12 @@ module.exports.BufferUtil = {
     }
   },
   mask: function(source, mask, output, offset, length) {
-    var maskNum = mask.readUInt32LE(0, true);
+    var maskNum = mask.readUInt32LE(0);
     var i = 0;
     for (; i < length - 3; i += 4) {
-      var num = maskNum ^ source.readUInt32LE(i, true);
+      var num = maskNum ^ source.readUInt32LE(i);
       if (num < 0) { num = 4294967296 + num; }
-      output.writeUInt32LE(num, offset + i, true);
+      output.writeUInt32LE(num, offset + i);
     }
     switch (length % 4) {
       case 3: output[offset + i + 2] = source[i + 2] ^ mask[2];
@@ -32,13 +32,13 @@ module.exports.BufferUtil = {
     }
   },
   unmask: function(data, mask) {
-    var maskNum = mask.readUInt32LE(0, true);
+    var maskNum = mask.readUInt32LE(0);
     var length = data.length;
     var i = 0;
     for (; i < length - 3; i += 4) {
-      var num = maskNum ^ data.readUInt32LE(i, true);
+      var num = maskNum ^ data.readUInt32LE(i);
       if (num < 0) { num = 4294967296 + num; }
-      data.writeUInt32LE(num, i, true);
+      data.writeUInt32LE(num, i);
     }
     switch (length % 4) {
       case 3: data[i + 2] = data[i + 2] ^ mask[2];

--- a/lib/WebSocketFrame.js
+++ b/lib/WebSocketFrame.js
@@ -85,7 +85,7 @@ WebSocketFrame.prototype.addData = function(bufferList) {
         if (bufferList.length >= 2) {
             bufferList.joinInto(this.frameHeader, 2, 0, 2);
             bufferList.advance(2);
-            this.length = this.frameHeader.readUInt16BE(2, true);
+            this.length = this.frameHeader.readUInt16BE(2);
             this.parseState = WAITING_FOR_MASK_KEY;
         }
     }
@@ -94,10 +94,10 @@ WebSocketFrame.prototype.addData = function(bufferList) {
             bufferList.joinInto(this.frameHeader, 2, 0, 8);
             bufferList.advance(8);
             var lengthPair = [
-              this.frameHeader.readUInt32BE(2, true),
-              this.frameHeader.readUInt32BE(2+4, true)
+              this.frameHeader.readUInt32BE(2),
+              this.frameHeader.readUInt32BE(2+4)
             ];
-            
+
             if (lengthPair[0] !== 0) {
                 this.protocolError = true;
                 this.dropReason = 'Unsupported 64-bit length frame received';
@@ -149,7 +149,7 @@ WebSocketFrame.prototype.addData = function(bufferList) {
                     this.invalidCloseFrameLength = true;
                 }
                 if (this.length >= 2) {
-                    this.closeStatus = this.binaryPayload.readUInt16BE(0, true);
+                    this.closeStatus = this.binaryPayload.readUInt16BE(0);
                     this.binaryPayload = this.binaryPayload.slice(2);
                 }
             }
@@ -204,7 +204,7 @@ WebSocketFrame.prototype.toBuffer = function(nullMask) {
             this.length += this.binaryPayload.length;
         }
         data = new Buffer(this.length);
-        data.writeUInt16BE(this.closeStatus, 0, true);
+        data.writeUInt16BE(this.closeStatus, 0);
         if (this.length > 2) {
             this.binaryPayload.copy(data, 2);
         }
@@ -242,20 +242,20 @@ WebSocketFrame.prototype.toBuffer = function(nullMask) {
 
     if (this.length > 125 && this.length <= 0xFFFF) {
         // write 16-bit length
-        output.writeUInt16BE(this.length, outputPos, true);
+        output.writeUInt16BE(this.length, outputPos);
         outputPos += 2;
     }
     else if (this.length > 0xFFFF) {
         // write 64-bit length
-        output.writeUInt32BE(0x00000000, outputPos, true);
-        output.writeUInt32BE(this.length, outputPos + 4, true);
+        output.writeUInt32BE(0x00000000, outputPos);
+        output.writeUInt32BE(this.length, outputPos + 4);
         outputPos += 8;
     }
 
     if (this.mask) {
-        maskKey = nullMask ? 0 : (Math.random()*0xFFFFFFFF) | 0;
-        this.maskBytes.writeUInt32BE(maskKey, 0, true);
-        
+        maskKey = nullMask ? 0 : ((Math.random() * 0xFFFFFFFF) >>> 0);
+        this.maskBytes.writeUInt32BE(maskKey, 0);
+
         // write the mask key
         this.maskBytes.copy(output, outputPos);
         outputPos += 4;


### PR DESCRIPTION
Support for the `noAssert` argument was removed for Node.js 10.x
and all input will be validated from now on nevertheless.

This removes all `noAssert` entries and fixes the possible overflow.

Refs: https://github.com/nodejs/node/pull/18395