### PR TITLE
update nan version to support new version of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "nan": "^2.3.3",
+    "nan": "^2.10.0",
     "typedarray-to-buffer": "^3.1.2",
     "yaeti": "^0.0.6"
   },


### PR DESCRIPTION
**This change fixed the compatibility of new version of node.**

**Environment: `ubuntu 16.04` + `node 9.10.0`**

**Something like `'ForceSet': is not a member of 'v8::Object'` will break the compile.**

It seems that due to the dramatic changes of `v8`, `nan` package also had some breaking change to support it. But in `nan@2.3.3`, `bufferutill` package will failed to compile.

Related issues: [nan#504](https://github.com/nodejs/nan/issues/504#issuecomment-385296082)

Maintainer of `nan` also states that this [nan](https://github.com/nodejs/nan#native-abstractions-for-nodejs)

