### PR TITLE
docs: Add windows-build-tools for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,17 @@ var W3CWebSocket = require('websocket').w3cwebsocket;
 
 Note for Windows Users
 ----------------------
-Because there is a small C++ component used for validating UTF-8 data, you will need to install a few other software packages in addition to Node to be able to build this module:
+Because there is a small C++ component used for validating UTF-8 data, you will need to install 
+native build tools. You can install the required components using `windows-build-tools`:
+
+```ps1
+npm install --global --production windows-build-tools
+```
+
+Alternatively, install the required components:
 
 - [Microsoft Visual C++](http://www.microsoft.com/visualstudio/en-us/products/2010-editions/visual-cpp-express)
 - [Python 2.7](http://www.python.org/download/) (NOT Python 3.x)
-
 
 Current Features:
 -----------------


### PR DESCRIPTION
I've verified that Windows users need only the `windows-build-tools` package to compile `websocket`. Might be a nice addition for those on Windows, but feel free to close it if you'd rather not take the PR.

Thanks!