### PR TITLE
Fix memory leak with multiple WebSocket servers on the same HTTP server

### DIFF
--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -190,6 +190,7 @@ WebSocketServer.prototype.shutDown = function() {
 };
 
 WebSocketServer.prototype.handleUpgrade = function(request, socket) {
+    var self = this;
     var wsRequest = new WebSocketRequest(socket, request, this.config);
     try {
         wsRequest.readHandshake();
@@ -208,6 +209,9 @@ WebSocketServer.prototype.handleUpgrade = function(request, socket) {
 
     wsRequest.once('requestAccepted', this._handlers.requestAccepted);
     wsRequest.once('requestResolved', this._handlers.requestResolved);
+    socket.once('close', function () {
+        self._handlers.requestResolved(wsRequest);
+    });
 
     if (!this.config.autoAcceptConnections && utils.eventEmitterListenerCount(this, 'request') > 0) {
         this.emit('request', wsRequest);


### PR DESCRIPTION
My use case involves several WebSocket servers on the same HTTP server that each care about specific path in URL (for instance, one handles `ws://localhost/ws1` and another `ws://localhost/ws2`).
In this scenario I do not want to reject request if it doesn't correspond to particular WebSocketServer's path. However, if I do not accept and do not reject request, it will be kept in memory even after original socket connection is closed entirely.

One workaround is to use `wsServer.handleRequestResolved(request);`, which is not a public API and not intuitive.

I decided that at least when socket is closed, request should be removed from memory.

BTW, I'd also like to see `request.ignore()` method that allows to clean memory earlier (without explicitly accepting or rejecting the whole connection), but in either case, this PR is a last defense from memory leaks in mentioned and similar scenarios.