### PR TITLE
Fix Webpack global scope issue

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,4 +1,9 @@
-var _global = (function() { return this; })();
+var _global = (function () {
+	if (!this && typeof global !== 'undefined') {
+		return global;
+	}
+	return this;
+})();
 var NativeWebSocket = _global.WebSocket || _global.MozWebSocket;
 var websocket_version = require('./version');
 


### PR DESCRIPTION
In webpack 4 (Angular 8) 

```
var _global = (function () {
	return this;
})();
```

will return undefined causing "Cannot read property WebSocket of undefined". 

Resolves #287.