### PR TITLE
Move gulp back to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
   "dependencies": {
     "debug": "^2.2.0",
     "nan": "^2.14.0",
-    "gulp": "^4.0.2",
     "typedarray-to-buffer": "^3.1.5",
     "yaeti": "^0.0.6"
   },
   "devDependencies": {
     "buffer-equal": "^1.0.0",
     "faucet": "^0.0.1",
+    "gulp": "^4.0.2",
     "gulp-jshint": "^2.0.4",
     "jshint-stylish": "^2.2.1",
     "jshint": "^2.0.0",


### PR DESCRIPTION
@ibc 

It looks like `WebSocket-Node` does not depend on `gulp` at runtime

Moving `gulp@^4.0.2` to `devDependencies` which make the project(which use websocket) do not have to install `gulp@^4.0.2` 😄 

original change [here](https://github.com/theturtle32/WebSocket-Node/commit/3cb29e1041ecca0a9c21f809890204271900f6f6)