### PR TITLE
Expose parse options flags to readHandshake phase

### DIFF
--- a/docs/WebSocketServer.md
+++ b/docs/WebSocketServer.md
@@ -85,6 +85,12 @@ by a trusted proxy or other intermediary within your own
 infrastructure.
 More info: [X-Forwarded-For on Wikipedia](http://en.wikipedia.org/wiki/X-Forwarded-For)
 
+**parseExtensions** - Boolean - *Default: true*
+Whether or not to parse 'sec-websocket-extension' headers. Array is exposed to WebSocketRequest.requestedExtensions.
+
+**parseCookies** - Boolean - *Default: true*
+Whether or not to parse 'cookie' headers. Array is exposed to WebSocketRequest.cookies.
+
 Events
 ------
 There are three events emitted by a WebSocketServer instance that allow you to handle incoming requests, establish connections, and detect when a connection has been closed.
@@ -103,3 +109,6 @@ Emitted whenever a new WebSocket connection is accepted.
 `function(webSocketConnection, closeReason, description)`
 
 Whenever a connection is closed for any reason, the WebSocketServer instance will emit a `close` event, passing a reference to the WebSocketConnection instance that was closed.  `closeReason` is the numeric reason status code for the connection closure, and `description` is a textual description of the close reason, if available.
+
+### close
+`function(webSocketConnection, closeReason, description)`

--- a/docs/WebSocketServer.md
+++ b/docs/WebSocketServer.md
@@ -110,5 +110,7 @@ Emitted whenever a new WebSocket connection is accepted.
 
 Whenever a connection is closed for any reason, the WebSocketServer instance will emit a `close` event, passing a reference to the WebSocketConnection instance that was closed.  `closeReason` is the numeric reason status code for the connection closure, and `description` is a textual description of the close reason, if available.
 
-### close
-`function(webSocketConnection, closeReason, description)`
+### upgradeError
+`function(error)`
+
+Emitted whenever a WebSocket error happens during the connection upgrade phase. Note that the WS connection is automatically rejected with a 400 error code, this event just exposes the error.

--- a/lib/WebSocketRequest.js
+++ b/lib/WebSocketRequest.js
@@ -95,13 +95,13 @@ function WebSocketRequest(socket, httpRequest, serverConfig) {
     this.remoteAddress = socket.remoteAddress;
     this.remoteAddresses = [this.remoteAddress];
     this.serverConfig = serverConfig;
-    
+
     // Watch for the underlying TCP socket closing before we call accept
     this._socketIsClosing = false;
     this._socketCloseHandler = this._handleSocketCloseBeforeAccept.bind(this);
     this.socket.on('end', this._socketCloseHandler);
     this.socket.on('close', this._socketCloseHandler);
-    
+
     this._resolved = false;
 }
 
@@ -174,12 +174,20 @@ WebSocketRequest.prototype.readHandshake = function() {
     }
 
     // Extensions are optional.
-    var extensionsString = request.headers['sec-websocket-extensions'];
-    this.requestedExtensions = this.parseExtensions(extensionsString);
+    if (this.serverConfig.parseExtensions) {
+        var extensionsString = request.headers['sec-websocket-extensions'];
+        this.requestedExtensions = this.parseExtensions(extensionsString);
+    } else {
+        this.requestedExtensions = [];
+    }
 
     // Cookies are optional
-    var cookieString = request.headers['cookie'];
-    this.cookies = this.parseCookies(cookieString);
+    if (this.serverConfig.parseCookies) {
+        var cookieString = request.headers['cookie'];
+        this.cookies = this.parseCookies(cookieString);
+    } else {
+        this.cookies = [];
+    }
 };
 
 WebSocketRequest.prototype.parseExtensions = function(extensionsString) {
@@ -248,7 +256,7 @@ WebSocketRequest.prototype.parseCookies = function(str) {
 
 WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, cookies) {
     this._verifyResolution();
-    
+
     // TODO: Handle extensions
 
     var protocolFullCase;
@@ -426,21 +434,21 @@ WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, co
     // if (negotiatedExtensions) {
     //     response += 'Sec-WebSocket-Extensions: ' + negotiatedExtensions.join(', ') + '\r\n';
     // }
-    
+
     // Mark the request resolved now so that the user can't call accept or
     // reject a second time.
     this._resolved = true;
     this.emit('requestResolved', this);
-    
+
     response += '\r\n';
 
     var connection = new WebSocketConnection(this.socket, [], acceptedProtocol, false, this.serverConfig);
     connection.webSocketVersion = this.webSocketVersion;
     connection.remoteAddress = this.remoteAddress;
     connection.remoteAddresses = this.remoteAddresses;
-    
+
     var self = this;
-    
+
     if (this._socketIsClosing) {
         // Handle case when the client hangs up before we get a chance to
         // accept the connection and send our side of the opening handshake.
@@ -452,7 +460,7 @@ WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, co
                 cleanupFailedConnection(connection);
                 return;
             }
-            
+
             self._removeSocketCloseListeners();
             connection._addSocketEventListeners();
         });
@@ -464,12 +472,12 @@ WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, co
 
 WebSocketRequest.prototype.reject = function(status, reason, extraHeaders) {
     this._verifyResolution();
-    
+
     // Mark the request resolved now so that the user can't call accept or
     // reject a second time.
     this._resolved = true;
     this.emit('requestResolved', this);
-    
+
     if (typeof(status) !== 'number') {
         status = 403;
     }

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -116,6 +116,12 @@ WebSocketServer.prototype.mount = function(config) {
         // See:  http://en.wikipedia.org/wiki/X-Forwarded-For
         ignoreXForwardedFor: false,
 
+        // If this is true, 'cookie' headers are parsed and exposed as WebSocketRequest.cookies
+        parseCookies: true,
+
+        // If this is true, 'sec-websocket-extensions' headers are parsed and exposed as WebSocketRequest.requestedExtensions
+        parseExtensions: true,
+
         // The Nagle Algorithm makes more efficient use of network resources
         // by introducing a small delay before sending small packets so that
         // multiple messages can be batched together before going onto the

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -208,7 +208,7 @@ WebSocketServer.prototype.handleUpgrade = function(request, socket) {
             e.headers
         );
         debug('Invalid handshake: %s', e.message);
-        this.emit('handshakeError', e);
+        this.emit('upgradeError', e);
         return;
     }
 

--- a/lib/WebSocketServer.js
+++ b/lib/WebSocketServer.js
@@ -202,9 +202,10 @@ WebSocketServer.prototype.handleUpgrade = function(request, socket) {
             e.headers
         );
         debug('Invalid handshake: %s', e.message);
+        this.emit('handshakeError', e);
         return;
     }
-    
+
     this.pendingRequests.push(wsRequest);
 
     wsRequest.once('requestAccepted', this._handlers.requestAccepted);


### PR DESCRIPTION
Hi there,

While using the library I noticed that some users were having the following error:

```
Invalid handshake URIError: URI malformed
2020-10-23T13:30:17:     at decodeURIComponent (<anonymous>)
2020-10-23T13:30:17:     at XXX/node_modules/websocket/lib/WebSocketRequest.js:242:20
```

I've tracked down this to `WebSocketServer.prototype.handleUpgrade` function. If for any reason the websocket contains a cookie that fails while calling `decodeURIComponent` in `WebSocketRequest.prototype.parseCookies`.

The the error is only available by looking at the process stdout which is a causes application observability problem as it's difficult to see how often this happens.

**This PR adds the following**

1. Expose readHandshake errors to main app by adding `upgradeError` event. 
2. Allow users to toggle parsing steps - `parseCookies`, `parseExtensions`

**How to reproduce it**
Set cookie header to 'as=%E0%A4%A'.


Let me know if you need more info. Thanks.