### PR TITLE
Add W3C Caveat to Browser Support Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Changelog
 Browser Support
 ---------------
 
-All current browsers are fully supported.
+All current browsers are fully* supported.
 
 * Firefox 7-9 (Old) (Protocol Version 8)
 * Firefox 10+ (Protocol Version 13)
@@ -39,6 +39,8 @@ All current browsers are fully supported.
 * Chrome 16+ (Protocol Version 13)
 * Internet Explorer 10+ (Protocol Version 13)
 * Safari 6+ (Protocol Version 13)
+
+(Not all W3C WebSocket features are supported by browsers. More info in the [Full API documentation](docs/index.md))
 
 Benchmarks
 ----------


### PR DESCRIPTION
The README states that "All current browsers are fully supported", which is not technically true. As noted in the [docs](https://github.com/theturtle32/WebSocket-Node/blob/master/docs/W3CWebSocket.md#constructor)

> When running in a browser (for example by using browserify) the browser's native WebSocket implementation is used, and thus just the first and second arguments (requestUrl and requestedProtocols) are used (those allowed by the W3C WebSocket API).

As someone who was not familiar with this, I spent a lot of time trying to debug the inconsistencies with the library between Node and the Browser. 

Even better would be if there were a way to throw an error when someone tries to pass headers, etc. into the W3C client from the browser.