### PR TITLE
add config.keepaliveForce

### DIFF
--- a/lib/WebSocketConnection.js
+++ b/lib/WebSocketConnection.js
@@ -262,7 +262,9 @@ WebSocketConnection.prototype.handleGracePeriodTimer = function() {
 WebSocketConnection.prototype.handleSocketData = function(data) {
     this._debug('handleSocketData');
     // Reset the keepalive timer when receiving data of any kind.
-    this.setKeepaliveTimer();
+    if (!this.config.keepaliveForce) {	
+    	this.setKeepaliveTimer();
+    }
 
     // Add received data to our bufferList, which efficiently holds received
     // data chunks in a linked list of Buffer objects.


### PR DESCRIPTION
Why?

If you have ever worked with web3 subscriptions, in particular with infura's node, you will stop receiving messages after a few minutes of inactivity.

When a subscription its established for example a subscription to logs, there would be only incomming messages from the node.

The package currently doesn't ping if messages are being received.

I propose adding this option keepaliveForce, that would force the keepalive to be sent

Here you can see workarounds that need to be done, but could be solved if this option its enabled

https://medium.com/@pauloostenrijk/infura-drops-your-websocket-connections-after-a-while-and-here-is-a-fix-for-it-3413ca8253b