### PR TITLE
Server Feat: connection2w3cwebsocket

### DIFF
--- a/lib/W3CWebSocket.js
+++ b/lib/W3CWebSocket.js
@@ -15,22 +15,23 @@
  ***********************************************************************/
 
 var WebSocketClient = require('./WebSocketClient');
-var toBuffer = require('typedarray-to-buffer');
-var yaeti = require('yaeti');
+var util = require('util');
 
 
-const CONNECTING = 0;
-const OPEN = 1;
-const CLOSING = 2;
-const CLOSED = 3;
+var wrapper = require('./W3CWebSocketWrapper');
+var W3CWebSocketWrapper = wrapper.W3CWebSocketWrapper;
+var onConnect = wrapper.onConnect;
+var onConnectFailed = wrapper.onConnectFailed;
 
 
 module.exports = W3CWebSocket;
 
 
 function W3CWebSocket(url, protocols, origin, headers, requestOptions, clientConfig) {
-    // Make this an EventTarget.
-    yaeti.EventTarget.call(this);
+    W3CWebSocketWrapper.call(this);
+    this.addEventListener('close', function(){
+      this._client.removeAllListeners();
+    });
 
     // Sanitize clientConfig.
     clientConfig = clientConfig || {};
@@ -39,14 +40,7 @@ function W3CWebSocket(url, protocols, origin, headers, requestOptions, clientCon
     var self = this;
 
     this._url = url;
-    this._readyState = CONNECTING;
     this._protocol = undefined;
-    this._extensions = '';
-    this._bufferedAmount = 0;  // Hack, always 0.
-    this._binaryType = 'arraybuffer';  // TODO: Should be 'blob' by default, but Node has no Blob.
-
-    // The WebSocketConnection instance.
-    this._connection = undefined;
 
     // WebSocketClient instance.
     this._client = new WebSocketClient(clientConfig);
@@ -62,196 +56,4 @@ function W3CWebSocket(url, protocols, origin, headers, requestOptions, clientCon
     this._client.connect(url, protocols, origin, headers, requestOptions);
 }
 
-
-// Expose W3C read only attributes.
-Object.defineProperties(W3CWebSocket.prototype, {
-    url:            { get: function() { return this._url;            } },
-    readyState:     { get: function() { return this._readyState;     } },
-    protocol:       { get: function() { return this._protocol;       } },
-    extensions:     { get: function() { return this._extensions;     } },
-    bufferedAmount: { get: function() { return this._bufferedAmount; } }
-});
-
-
-// Expose W3C write/read attributes.
-Object.defineProperties(W3CWebSocket.prototype, {
-    binaryType: {
-        get: function() {
-            return this._binaryType;
-        },
-        set: function(type) {
-            // TODO: Just 'arraybuffer' supported.
-            if (type !== 'arraybuffer') {
-                throw new SyntaxError('just "arraybuffer" type allowed for "binaryType" attribute');
-            }
-            this._binaryType = type;
-        }
-    }
-});
-
-
-// Expose W3C readyState constants into the WebSocket instance as W3C states.
-[['CONNECTING',CONNECTING], ['OPEN',OPEN], ['CLOSING',CLOSING], ['CLOSED',CLOSED]].forEach(function(property) {
-    Object.defineProperty(W3CWebSocket.prototype, property[0], {
-        get: function() { return property[1]; }
-    });
-});
-
-// Also expose W3C readyState constants into the WebSocket class (not defined by the W3C,
-// but there are so many libs relying on them).
-[['CONNECTING',CONNECTING], ['OPEN',OPEN], ['CLOSING',CLOSING], ['CLOSED',CLOSED]].forEach(function(property) {
-    Object.defineProperty(W3CWebSocket, property[0], {
-        get: function() { return property[1]; }
-    });
-});
-
-
-W3CWebSocket.prototype.send = function(data) {
-    if (this._readyState !== OPEN) {
-        throw new Error('cannot call send() while not connected');
-    }
-
-    // Text.
-    if (typeof data === 'string' || data instanceof String) {
-        this._connection.sendUTF(data);
-    }
-    // Binary.
-    else {
-        // Node Buffer.
-        if (data instanceof Buffer) {
-            this._connection.sendBytes(data);
-        }
-        // If ArrayBuffer or ArrayBufferView convert it to Node Buffer.
-        else if (data.byteLength || data.byteLength === 0) {
-            data = toBuffer(data);
-            this._connection.sendBytes(data);
-        }
-        else {
-            throw new Error('unknown binary data:', data);
-        }
-    }
-};
-
-
-W3CWebSocket.prototype.close = function(code, reason) {
-    switch(this._readyState) {
-        case CONNECTING:
-            // NOTE: We don't have the WebSocketConnection instance yet so no
-            // way to close the TCP connection.
-            // Artificially invoke the onConnectFailed event.
-            onConnectFailed.call(this);
-            // And close if it connects after a while.
-            this._client.on('connect', function(connection) {
-                if (code) {
-                    connection.close(code, reason);
-                } else {
-                    connection.close();
-                }
-            });
-            break;
-        case OPEN:
-            this._readyState = CLOSING;
-            if (code) {
-                this._connection.close(code, reason);
-            } else {
-                this._connection.close();
-            }
-            break;
-        case CLOSING:
-        case CLOSED:
-            break;
-    }
-};
-
-
-/**
- * Private API.
- */
-
-
-function createCloseEvent(code, reason) {
-    var event = new yaeti.Event('close');
-
-    event.code = code;
-    event.reason = reason;
-    event.wasClean = (typeof code === 'undefined' || code === 1000);
-
-    return event;
-}
-
-
-function createMessageEvent(data) {
-    var event = new yaeti.Event('message');
-
-    event.data = data;
-
-    return event;
-}
-
-
-function onConnect(connection) {
-    var self = this;
-
-    this._readyState = OPEN;
-    this._connection = connection;
-    this._protocol = connection.protocol;
-    this._extensions = connection.extensions;
-
-    this._connection.on('close', function(code, reason) {
-        onClose.call(self, code, reason);
-    });
-
-    this._connection.on('message', function(msg) {
-        onMessage.call(self, msg);
-    });
-
-    this.dispatchEvent(new yaeti.Event('open'));
-}
-
-
-function onConnectFailed() {
-    destroy.call(this);
-    this._readyState = CLOSED;
-
-    try {
-        this.dispatchEvent(new yaeti.Event('error'));
-    } finally {
-        this.dispatchEvent(createCloseEvent(1006, 'connection failed'));
-    }
-}
-
-
-function onClose(code, reason) {
-    destroy.call(this);
-    this._readyState = CLOSED;
-
-    this.dispatchEvent(createCloseEvent(code, reason || ''));
-}
-
-
-function onMessage(message) {
-    if (message.utf8Data) {
-        this.dispatchEvent(createMessageEvent(message.utf8Data));
-    }
-    else if (message.binaryData) {
-        // Must convert from Node Buffer to ArrayBuffer.
-        // TODO: or to a Blob (which does not exist in Node!).
-        if (this.binaryType === 'arraybuffer') {
-            var buffer = message.binaryData;
-            var arraybuffer = new ArrayBuffer(buffer.length);
-            var view = new Uint8Array(arraybuffer);
-            for (var i=0, len=buffer.length; i<len; ++i) {
-                view[i] = buffer[i];
-            }
-            this.dispatchEvent(createMessageEvent(arraybuffer));
-        }
-    }
-}
-
-
-function destroy() {
-    this._client.removeAllListeners();
-    if (this._connection) {
-        this._connection.removeAllListeners();
-    }
-}
+util.inherits(W3CWebSocket, W3CWebSocketWrapper);

--- a/lib/W3CWebSocketWrapper.js
+++ b/lib/W3CWebSocketWrapper.js
@@ -24,28 +24,28 @@ const CLOSING = 2;
 const CLOSED = 3;
 
 module.exports = {
-  W3CWebSocketWrapper,
-  onConnect,
-  onConnectFailed,
-  connToW3C
+    W3CWebSocketWrapper: W3CWebSocketWrapper,
+    onConnect: onConnect,
+    onConnectFailed: onConnectFailed,
+    connToW3C: connToW3C
 };
 
 function connToW3C(connection){
-  const w3c = new W3CWebSocketWrapper();
-  onConnect.call(w3c, connection);
-  return w3c;
+    const w3c = new W3CWebSocketWrapper();
+    onConnect.call(w3c, connection);
+    return w3c;
 }
 
 function W3CWebSocketWrapper(){
-  // Make this an EventTarget.
-  yaeti.EventTarget.call(this);
-  this._readyState = CONNECTING;
-  this._extensions = '';
-  this._bufferedAmount = 0;  // Hack, always 0.
-  this._binaryType = 'arraybuffer';  // TODO: Should be 'blob' by default, but Node has no Blob.
+    // Make this an EventTarget.
+    yaeti.EventTarget.call(this);
+    this._readyState = CONNECTING;
+    this._extensions = '';
+    this._bufferedAmount = 0;  // Hack, always 0.
+    this._binaryType = 'arraybuffer';  // TODO: Should be 'blob' by default, but Node has no Blob.
 
-  // The WebSocketConnection instance.
-  this._connection = undefined;
+    // The WebSocketConnection instance.
+    this._connection = undefined;
 }
 
 

--- a/lib/W3CWebSocketWrapper.js
+++ b/lib/W3CWebSocketWrapper.js
@@ -1,0 +1,242 @@
+/************************************************************************
+ *  Copyright 2010-2015 Brian McKelvey.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ***********************************************************************/
+
+var toBuffer = require('typedarray-to-buffer');
+var yaeti = require('yaeti');
+
+
+const CONNECTING = 0;
+const OPEN = 1;
+const CLOSING = 2;
+const CLOSED = 3;
+
+module.exports = {
+  W3CWebSocketWrapper,
+  onConnect,
+  onConnectFailed,
+  connToW3C
+};
+
+function connToW3C(connection){
+  const w3c = new W3CWebSocketWrapper();
+  onConnect.call(w3c, connection);
+  return w3c;
+}
+
+function W3CWebSocketWrapper(){
+  // Make this an EventTarget.
+  yaeti.EventTarget.call(this);
+  this._readyState = CONNECTING;
+  this._extensions = '';
+  this._bufferedAmount = 0;  // Hack, always 0.
+  this._binaryType = 'arraybuffer';  // TODO: Should be 'blob' by default, but Node has no Blob.
+
+  // The WebSocketConnection instance.
+  this._connection = undefined;
+}
+
+
+// Expose W3C read only attributes.
+Object.defineProperties(W3CWebSocketWrapper.prototype, {
+    url:            { get: function() { return this._url;            } },
+    readyState:     { get: function() { return this._readyState;     } },
+    protocol:       { get: function() { return this._protocol;       } },
+    extensions:     { get: function() { return this._extensions;     } },
+    bufferedAmount: { get: function() { return this._bufferedAmount; } }
+});
+
+
+// Expose W3C write/read attributes.
+Object.defineProperties(W3CWebSocketWrapper.prototype, {
+    binaryType: {
+        get: function() {
+            return this._binaryType;
+        },
+        set: function(type) {
+            // TODO: Just 'arraybuffer' supported.
+            if (type !== 'arraybuffer') {
+                throw new SyntaxError('just "arraybuffer" type allowed for "binaryType" attribute');
+            }
+            this._binaryType = type;
+        }
+    }
+});
+
+
+// Expose W3C readyState constants into the WebSocket instance as W3C states.
+[['CONNECTING',CONNECTING], ['OPEN',OPEN], ['CLOSING',CLOSING], ['CLOSED',CLOSED]].forEach(function(property) {
+    Object.defineProperty(W3CWebSocketWrapper.prototype, property[0], {
+        get: function() { return property[1]; }
+    });
+});
+
+// Also expose W3C readyState constants into the WebSocket class (not defined by the W3C,
+// but there are so many libs relying on them).
+[['CONNECTING',CONNECTING], ['OPEN',OPEN], ['CLOSING',CLOSING], ['CLOSED',CLOSED]].forEach(function(property) {
+    Object.defineProperty(W3CWebSocketWrapper, property[0], {
+        get: function() { return property[1]; }
+    });
+});
+
+
+W3CWebSocketWrapper.prototype.send = function(data) {
+    if (this._readyState !== OPEN) {
+        throw new Error('cannot call send() while not connected');
+    }
+
+    // Text.
+    if (typeof data === 'string' || data instanceof String) {
+        this._connection.sendUTF(data);
+    }
+    // Binary.
+    else {
+        // Node Buffer.
+        if (data instanceof Buffer) {
+            this._connection.sendBytes(data);
+        }
+        // If ArrayBuffer or ArrayBufferView convert it to Node Buffer.
+        else if (data.byteLength || data.byteLength === 0) {
+            data = toBuffer(data);
+            this._connection.sendBytes(data);
+        }
+        else {
+            throw new Error('unknown binary data:', data);
+        }
+    }
+};
+
+
+W3CWebSocketWrapper.prototype.close = function(code, reason) {
+    switch(this._readyState) {
+        case CONNECTING:
+            // NOTE: We don't have the WebSocketConnection instance yet so no
+            // way to close the TCP connection.
+            // Artificially invoke the onConnectFailed event.
+            onConnectFailed.call(this);
+            // And close if it connects after a while.
+            this._client.on('connect', function(connection) {
+                if (code) {
+                    connection.close(code, reason);
+                } else {
+                    connection.close();
+                }
+            });
+            break;
+        case OPEN:
+            this._readyState = CLOSING;
+            if (code) {
+                this._connection.close(code, reason);
+            } else {
+                this._connection.close();
+            }
+            break;
+        case CLOSING:
+        case CLOSED:
+            break;
+    }
+};
+
+
+/**
+ * Private API.
+ */
+
+
+function createCloseEvent(code, reason) {
+    var event = new yaeti.Event('close');
+
+    event.code = code;
+    event.reason = reason;
+    event.wasClean = (typeof code === 'undefined' || code === 1000);
+
+    return event;
+}
+
+
+function createMessageEvent(data) {
+    var event = new yaeti.Event('message');
+
+    event.data = data;
+
+    return event;
+}
+
+
+function onConnect(connection) {
+    var self = this;
+
+    this._readyState = OPEN;
+    this._connection = connection;
+    this._protocol = connection.protocol;
+    this._extensions = connection.extensions;
+
+    this._connection.on('close', function(code, reason) {
+        onClose.call(self, code, reason);
+    });
+
+    this._connection.on('message', function(msg) {
+        onMessage.call(self, msg);
+    });
+
+    this.dispatchEvent(new yaeti.Event('open'));
+}
+
+
+function onConnectFailed() {
+    destroy.call(this);
+    this._readyState = CLOSED;
+
+    try {
+        this.dispatchEvent(new yaeti.Event('error'));
+    } finally {
+        this.dispatchEvent(createCloseEvent(1006, 'connection failed'));
+    }
+}
+
+
+function onClose(code, reason) {
+    destroy.call(this);
+    this._readyState = CLOSED;
+
+    this.dispatchEvent(createCloseEvent(code, reason || ''));
+}
+
+
+function onMessage(message) {
+    if (message.utf8Data) {
+        this.dispatchEvent(createMessageEvent(message.utf8Data));
+    }
+    else if (message.binaryData) {
+        // Must convert from Node Buffer to ArrayBuffer.
+        // TODO: or to a Blob (which does not exist in Node!).
+        if (this.binaryType === 'arraybuffer') {
+            var buffer = message.binaryData;
+            var arraybuffer = new ArrayBuffer(buffer.length);
+            var view = new Uint8Array(arraybuffer);
+            for (var i=0, len=buffer.length; i<len; ++i) {
+                view[i] = buffer[i];
+            }
+            this.dispatchEvent(createMessageEvent(arraybuffer));
+        }
+    }
+}
+
+
+function destroy() {
+    if (this._connection) {
+        this._connection.removeAllListeners();
+    }
+}

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -6,6 +6,7 @@ module.exports = {
     'request'      : require('./WebSocketRequest'),
     'connection'   : require('./WebSocketConnection'),
     'w3cwebsocket' : require('./W3CWebSocket'),
+    'connection2w3cwebsocket': require('./W3CWebSocketWrapper').connToW3C,
     'deprecation'  : require('./Deprecation'),
     'version'      : require('./version')
 };

--- a/test/unit/connectionToW3c.js
+++ b/test/unit/connectionToW3c.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+var test = require('tape');
+var WebSocket = require('../../lib/W3CWebSocket');
+var connToW3C = require('../../lib/W3CWebSocketWrapper').connToW3C;
+var server = require('../shared/test-server');
+var stopServer = server.stopServer;
+
+test('conn2W3C adding event listeners with ws.onxxxxx', function(t) {
+  var counter = 0;
+  var message = 'This is a test message.';
+  t.on('end', ()=>{
+    stopServer();
+  });
+  server.prepare(function(err, wsServer) {
+    if (err) {
+      t.fail('Unable to start test server');
+      return t.end();
+    }
+    wsServer.once('request', function(request){
+      var connection = request.accept();
+      var sw3c = connToW3C(connection);
+      // open gets called within the connToW3C. It cannot be listened to
+      ++counter;
+      sw3c.send(message);
+      sw3c.onerror = function(event) {
+        t.fail('No errors are expected: ' + event);
+      };
+      sw3c.onmessage = function(event) {
+        t.equal(++counter, 2, 'onmessage should be called second');
+
+        t.equal(event.data, message, 'Server received message data should match sent message data.');
+        sw3c.close();
+      };
+      sw3c.onclose = function(event) {
+        t.equal(++counter, 3, 'onclose should be called last');
+        t.end();
+      };
+    });
+
+    var cw3c = new WebSocket('ws://localhost:64321/');
+    cw3c.onmessage = function(event){
+      t.equal(event.data, message, 'Client received message data should match sent message data.');
+      cw3c.send(event.data);
+    };
+  });
+});
+
+test('conn2W3C adding event listeners with ws.addEventListener', function(t) {
+  var counter = 0;
+  var message = 'This is a test message.';
+  t.on('end', function(){
+    stopServer();
+  });
+  server.prepare(function(err, wsServer) {
+    if (err) {
+      t.fail('Unable to start test server');
+      return t.end();
+    }
+    wsServer.once('request', function(request){
+      var connection = request.accept();
+      var sw3c = connToW3C(connection);
+      // open gets called within the connToW3C. It cannot be listened to
+      ++counter;
+      sw3c.send(message);
+      sw3c.addEventListener('error', function(event) {
+        t.fail('No errors are expected: ' + event);
+      });
+      sw3c.addEventListener('message', function(event) {
+        t.equal(++counter, 2, 'onmessage should be called second');
+
+        t.equal(event.data, message, 'Server received message data should match sent message data.');
+        sw3c.close();
+      });
+      sw3c.addEventListener('close', function(event) {
+        t.equal(++counter, 3, 'onclose should be called last');
+        t.end();
+      });
+    });
+
+    var cw3c = new WebSocket('ws://localhost:64321/');
+    cw3c.addEventListener('message', function(event){
+      t.equal(event.data, message, 'Client received message data should match sent message data.');
+      cw3c.send(event.data);
+    });
+  });
+});
+
+test('conn2W3C open event doesn\'t get emitted externally', function(t) {
+  var message = 'This is a test message.';
+  t.on('end', function(){
+    stopServer();
+  });
+  server.prepare(function(err, wsServer) {
+    if (err) {
+      t.fail('Unable to start test server');
+      return t.end();
+    }
+    wsServer.once('request', function(request){
+      var connection = request.accept();
+      var sw3c = connToW3C(connection);
+      sw3c.addEventListener('open', function(){
+        t.fail('open event fired');
+      });
+      sw3c.addEventListener('message', function(event){
+        t.equal(event.data, message, 'Server received message data should match sent message data.');
+        sw3c.close();
+      });
+      sw3c.addEventListener('close', function() {
+        t.end();
+      });
+    });
+    var cw3c = new WebSocket('ws://localhost:64321/');
+    setTimeout(function(){
+      cw3c.send(message);
+    }, 100);
+  });
+});


### PR DESCRIPTION
Your websockets do some good stuff but, for consistencies sake and perhaps some browserify action, I wanted to use the W3CWebsocket interface with a server connection. I had forked your project a while ago but I suppose I wasn't able to figure out how to get it done. Well, I got it done.

**Notes**
- connection2w3cwebsocket is a very simple function
- `W3CWebSocket` now inherits `W3CWebSocketWrapper` and much of the guts have been moved over there
- Right now, `W3CWebSocket` listens to the close event to cleanup it's client.
  - this covers client failure, close while connecting and normal closing
  - If ever a consumer decided to remove all event listeners for this, the client will not get cleaned up.
  - This is also the case for some of the connection close events. Hopefully, nobody does something silly
- I didn't know what to name W3CWebSocketWrapper
- I added some tests, effectively just copied the W3CWebSocket tests.
  - the server based W3CWebSocket doesn't emit an open event.
  - I considered doing a Promise.resolve() then opening it but I'm not sure if its relevant
  - I'm definitely open to to implementing one if that is important it really should be easy