### PR TITLE
Updated the package es5-ext from 0.10.50 to 0.10.63

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "bufferutil": "^4.0.1",
     "debug": "^2.2.0",
-    "es5-ext": "^0.10.50",
+    "es5-ext": "^0.10.63",
     "typedarray-to-buffer": "^3.1.5",
     "utf-8-validate": "^5.0.2",
     "yaeti": "^0.0.6"


### PR DESCRIPTION
1. Veracode platform identifies a high-level vulnerability in the dependency package es5-ext (Dependency of WebSocket).
2. I encountered this issue while using WebSocket version 1.0.33, which relies on es5-ext version 0.10.62.
3. According to the npm WebSocket documentation, the latest version available is 1.0.34, released on April 14, 2021.
4. Upon installing the latest WebSocket version, 1.0.34, I discovered it still depends on es5-ext version 0.10.62.
5. To address this, I've updated es5-ext to version 0.10.63.
6. I kindly request the team to merge this PR to resolve the vulnerability issue.