### PR TITLE
Fix cookie expiration validation typo

### DIFF
--- a/lib/WebSocketRequest.js
+++ b/lib/WebSocketRequest.js
@@ -386,7 +386,7 @@ WebSocketRequest.prototype.accept = function(acceptedProtocol, allowedOrigin, co
             if (cookie.expires) {
                 if (!(cookie.expires instanceof Date)){
                     this.reject(500);
-                    throw new Error('Value supplied for cookie "expires" must be a vaild date object');
+                    throw new Error('Value supplied for cookie "expires" must be a valid date object');
                 }
                 cookieParts.push('Expires=' + cookie.expires.toGMTString());
             }


### PR DESCRIPTION
## Summary
- fix typo in cookie expiration validation error message

## Testing
- `npm test` *(fails: `tape` not found)*