### PR TITLE
Refactor: drop `es5-ext`

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,14 +1,23 @@
 var _globalThis;
-if (typeof globalThis === 'object') {
-	_globalThis = globalThis;
-} else {
-	try {
-		_globalThis = require('es5-ext/global');
-	} catch (error) {
-	} finally {
-		if (!_globalThis && typeof window !== 'undefined') { _globalThis = window; }
-		if (!_globalThis) { throw new Error('Could not determine global this'); }
-	}
+
+/**
+ * core-js | Denis Pushkarev (zloirock) | MIT License
+ *
+ * https://github.com/zloirock/core-js/blob/977a3a49eb9473edf470cbc5c4257bd7c8c4da33/packages/core-js/internals/global-this.js#L1
+ */
+var checkGlobal = function (it) {
+  return it && it.Math === Math && it;
+};
+var _globalThis =
+	checkGlobal(typeof globalThis === 'object' && globalThis) ||
+	checkGlobal(typeof window === 'object' && window) ||
+	checkGlobal(typeof self === 'object' && self) ||
+	checkGlobal(typeof global === 'object' && global) ||
+	checkGlobal(typeof this === 'object' && this) ||
+	(function () { return this; })();
+
+if (!_globalThis) {
+	throw new Error('Could not determine global this');
 }
 
 var NativeWebSocket = _globalThis.WebSocket || _globalThis.MozWebSocket;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "bufferutil": "^4.0.1",
     "debug": "^2.2.0",
-    "es5-ext": "^0.10.63",
     "typedarray-to-buffer": "^3.1.5",
     "utf-8-validate": "^5.0.2",
     "yaeti": "^0.0.6"
@@ -38,8 +37,8 @@
     "buffer-equal": "^1.0.0",
     "gulp": "^4.0.2",
     "gulp-jshint": "^2.0.4",
-    "jshint-stylish": "^2.2.1",
     "jshint": "^2.0.0",
+    "jshint-stylish": "^2.2.1",
     "tape": "^4.9.1"
   },
   "config": {


### PR DESCRIPTION
`es5-ext` was introduced to `WebSocket-Node` in 2019 by #362 to address #360. However:

- #362 **doesn't really fix** the webpack bundling issue.
  - `es5-ext/global` **still prefers** exactly the same `(function() { return this; })();` approach over `window` or `self`, the approach which #360 was trying to get rid of in the first place, see:
  - https://github.com/medikoo/es5-ext/blob/f76b03d8c49ce4871f37f428c0e1d3ee6637fcc4/global.js#L7-L8
- `es5-ext` is a huge and heavy dependency.
  - It will introduce [extra 643 KiB to the `node_modules` folder](https://pkg-size.dev/es5-ext).
  - It is not really being used by the majority of the user base (where they are running this library on Node.js). And even for those who are bundling this library with webpack/rollup/etc for running in the browser, `es5-ext/global` is still unnecessarily heavy.

The PR removes `es5-ext`, and instead uses the `globalThis` polyfill implementation from `core-js`.