### PR TITLE
Add performance metrics to Autobahn test parser

### DIFF
--- a/test/autobahn/parse-results.js
+++ b/test/autobahn/parse-results.js
@@ -47,6 +47,13 @@ function parseResults() {
     }
   };
   
+  // Category mapping for performance tests
+  const categoryMap = {
+    '9': 'limits',
+    '10': 'largeMessages',
+    '12': 'fragmentation'
+  };
+
   // Parse each test case
   for (const [testCase, result] of Object.entries(testResults)) {
     summary.total++;
@@ -99,18 +106,10 @@ function parseResults() {
 
       // Categorize performance tests
       const majorCategory = testCase.split('.')[0];
-      let category = 'other';
-
-      if (majorCategory === '9') {
-        category = 'limits';
-      } else if (majorCategory === '10') {
-        category = 'largeMessages';
-      } else if (majorCategory === '12') {
-        category = 'fragmentation';
-      }
+      const category = categoryMap[majorCategory] || 'other';
 
       summary.performance.byCategory[category].tests.push({
-        case: testCase,
+        testCase: testCase,
         duration: result.duration,
         description: result.description
       });
@@ -187,7 +186,7 @@ function parseResults() {
     console.log(`  Average duration: ${(summary.performance.totalDuration / summary.performance.testCount).toFixed(2)}ms\n`);
 
     // Print category breakdown for performance-focused tests
-    const perfCategories = ['limits', 'largeMessages', 'fragmentation'];
+    const perfCategories = Object.keys(summary.performance.byCategory).filter(key => key !== 'other');
     let hasPerfData = false;
 
     for (const categoryKey of perfCategories) {
@@ -201,14 +200,14 @@ function parseResults() {
         console.log(`    Average duration: ${avgDuration}ms`);
 
         // Show top 5 slowest tests in this category
-        const slowestTests = category.tests
+        const slowestTests = [...category.tests]
           .sort((a, b) => b.duration - a.duration)
           .slice(0, 5);
 
         if (slowestTests.length > 0) {
           console.log('    Slowest tests:');
           slowestTests.forEach(test => {
-            console.log(`      ${test.case}: ${test.duration}ms`);
+            console.log(`      ${test.testCase}: ${test.duration}ms`);
           });
         }
         console.log('');

--- a/test/autobahn/parse-results.js
+++ b/test/autobahn/parse-results.js
@@ -34,16 +34,26 @@ function parseResults() {
     failedTests: [],
     nonStrictTests: [],
     unimplementedTests: [],
-    informationalTests: []
+    informationalTests: [],
+    performance: {
+      totalDuration: 0,
+      testCount: 0,
+      byCategory: {
+        'limits': { tests: [], totalDuration: 0, description: '9.x - Limits/Performance' },
+        'largeMessages': { tests: [], totalDuration: 0, description: '10.x - Large Messages' },
+        'fragmentation': { tests: [], totalDuration: 0, description: '12.x - WebSocket Fragmentation' },
+        'other': { tests: [], totalDuration: 0, description: 'Other Tests' }
+      }
+    }
   };
   
   // Parse each test case
   for (const [testCase, result] of Object.entries(testResults)) {
     summary.total++;
-    
+
     const behavior = result.behavior;
     const behaviorClose = result.behaviorClose;
-    
+
     if (behavior === 'OK' && behaviorClose === 'OK') {
       summary.ok++;
     } else if (behavior === 'UNIMPLEMENTED') {
@@ -80,6 +90,31 @@ function parseResults() {
         duration: result.duration,
         remoteCloseCode: result.remoteCloseCode
       });
+    }
+
+    // Track performance metrics
+    if (result.duration !== undefined) {
+      summary.performance.totalDuration += result.duration;
+      summary.performance.testCount++;
+
+      // Categorize performance tests
+      const majorCategory = testCase.split('.')[0];
+      let category = 'other';
+
+      if (majorCategory === '9') {
+        category = 'limits';
+      } else if (majorCategory === '10') {
+        category = 'largeMessages';
+      } else if (majorCategory === '12') {
+        category = 'fragmentation';
+      }
+
+      summary.performance.byCategory[category].tests.push({
+        case: testCase,
+        duration: result.duration,
+        description: result.description
+      });
+      summary.performance.byCategory[category].totalDuration += result.duration;
     }
   }
   
@@ -144,7 +179,48 @@ function parseResults() {
     }
   }
   
-  console.log('\n');
+  // Print performance summary
+  if (summary.performance.testCount > 0) {
+    console.log('=== PERFORMANCE METRICS ===');
+    console.log(`  Total test duration: ${summary.performance.totalDuration.toLocaleString()}ms`);
+    console.log(`  Tests with timing data: ${summary.performance.testCount}`);
+    console.log(`  Average duration: ${(summary.performance.totalDuration / summary.performance.testCount).toFixed(2)}ms\n`);
+
+    // Print category breakdown for performance-focused tests
+    const perfCategories = ['limits', 'largeMessages', 'fragmentation'];
+    let hasPerfData = false;
+
+    for (const categoryKey of perfCategories) {
+      const category = summary.performance.byCategory[categoryKey];
+      if (category.tests.length > 0) {
+        hasPerfData = true;
+        const avgDuration = (category.totalDuration / category.tests.length).toFixed(2);
+        console.log(`  ${category.description}:`);
+        console.log(`    Tests: ${category.tests.length}`);
+        console.log(`    Total duration: ${category.totalDuration.toLocaleString()}ms`);
+        console.log(`    Average duration: ${avgDuration}ms`);
+
+        // Show top 5 slowest tests in this category
+        const slowestTests = category.tests
+          .sort((a, b) => b.duration - a.duration)
+          .slice(0, 5);
+
+        if (slowestTests.length > 0) {
+          console.log('    Slowest tests:');
+          slowestTests.forEach(test => {
+            console.log(`      ${test.case}: ${test.duration}ms`);
+          });
+        }
+        console.log('');
+      }
+    }
+
+    if (!hasPerfData) {
+      console.log('  No performance-focused tests (9.x, 10.x, 12.x) executed.\n');
+    }
+  }
+
+  console.log('');
 
   // Exit with error code if there are actual failures
   if (summary.failed > 0) {


### PR DESCRIPTION
## Summary
- Enhanced Autobahn test parser to capture and display timing/performance data
- Added tracking for performance-focused test series (9.x, 10.x, 12.x)
- Display performance summary with category breakdowns and slowest tests

## Performance Insights
The enhanced parser now reveals:
- **9.x (Limits/Performance)**: 54 tests, average 175.56ms per test
  - Slowest: 9.5.1 (685ms), 9.3.1 (642ms), 9.6.1 (532ms)
- **10.x (Large Messages)**: 1 test, average 7.00ms
- **12.x (Fragmentation)**: 90 tests, average 1.23ms (unimplemented)
- **Total test duration**: 20.7 seconds across 517 tests

## Test Plan
- [x] Ran `node test/autobahn/parse-results.js` successfully
- [x] Verified performance metrics display correctly
- [x] Confirmed all existing test result parsing still works
- [x] Ran `pnpm lint:fix` with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)