### PR TITLE
Suppress debug output during test runs

### DIFF
--- a/lib/WebSocketConnection.js
+++ b/lib/WebSocketConnection.js
@@ -313,7 +313,10 @@ class WebSocketConnection extends EventEmitter {
       this.emit('error', error);
     }
     this.socket.destroy();
-    this._debug.printOutput();
+    // Only print debug output in non-test environments to avoid cluttering test output
+    if (process.env.NODE_ENV !== 'test') {
+      this._debug.printOutput();
+    }
   }
 
   handleSocketEnd() {

--- a/test/shared/setup.mjs
+++ b/test/shared/setup.mjs
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, vi } from 'vitest';
 import { stopAllServers } from '../helpers/test-server.mjs';
+import debug from 'debug';
 
 // Increase max listeners to avoid warnings when running many tests with child processes
 // Vitest adds exit/beforeExit listeners for each test file with spawned processes
@@ -7,7 +8,6 @@ process.setMaxListeners(30);
 
 // Disable debug output during tests unless explicitly enabled
 if (!process.env.DEBUG) {
-  const debug = require('debug');
   debug.disable();
 }
 
@@ -30,7 +30,6 @@ afterEach(async () => {
 
   // Re-disable debug after each test to prevent leakage
   if (!process.env.DEBUG) {
-    const debug = require('debug');
     debug.disable();
   }
 });

--- a/test/shared/setup.mjs
+++ b/test/shared/setup.mjs
@@ -5,19 +5,34 @@ import { stopAllServers } from '../helpers/test-server.mjs';
 // Vitest adds exit/beforeExit listeners for each test file with spawned processes
 process.setMaxListeners(30);
 
+// Disable debug output during tests unless explicitly enabled
+if (!process.env.DEBUG) {
+  const debug = require('debug');
+  debug.disable();
+}
+
 // Global test setup for each test file
 beforeEach(() => {
   // Clear all mocks and timers
   vi.clearAllTimers();
   vi.clearAllMocks();
+
+  // Note: We don't disable debug in beforeEach as some tests need to enable it
+  // Tests that enable DEBUG should clean up properly in their own afterEach
 });
 
 afterEach(async () => {
   // Restore all mocks
   vi.restoreAllMocks();
-  
+
   // Clean up any test servers
   await stopAllServers();
+
+  // Re-disable debug after each test to prevent leakage
+  if (!process.env.DEBUG) {
+    const debug = require('debug');
+    debug.disable();
+  }
 });
 
 // Set up global test configuration

--- a/test/unit/core/utils-enhanced.test.mjs
+++ b/test/unit/core/utils-enhanced.test.mjs
@@ -20,8 +20,13 @@ describe('Utils Module - Enhanced Coverage', () => {
     });
 
     afterEach(() => {
+      const debug = require('debug');
+      debug.disable();
       if (originalDebugEnv !== undefined) {
         process.env.DEBUG = originalDebugEnv;
+        if (originalDebugEnv) {
+          debug.enable(originalDebugEnv);
+        }
       } else {
         delete process.env.DEBUG;
       }
@@ -62,8 +67,13 @@ describe('Utils Module - Enhanced Coverage', () => {
     });
 
     afterEach(() => {
+      const debug = require('debug');
+      debug.disable();
       if (originalDebugEnv !== undefined) {
         process.env.DEBUG = originalDebugEnv;
+        if (originalDebugEnv) {
+          debug.enable(originalDebugEnv);
+        }
       } else {
         delete process.env.DEBUG;
       }
@@ -81,9 +91,12 @@ describe('Utils Module - Enhanced Coverage', () => {
 
         expect(mockLog).toHaveBeenCalled();
         // Verify the format includes timestamp and uniqueID
+        // printOutput calls logFunction.apply(global, args) where args includes:
+        // [formatString, date, uniqueID, ...originalArgs]
         const firstCall = mockLog.mock.calls[0];
         expect(firstCall).toBeDefined();
-        expect(firstCall[0]).toContain('test-id');
+        // The uniqueID should be in args[2] (after formatString and date)
+        expect(firstCall[2]).toBe('test-id');
       }
     });
 

--- a/test/unit/core/utils-enhanced.test.mjs
+++ b/test/unit/core/utils-enhanced.test.mjs
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as utils from '../../../lib/utils.js';
+import debug from 'debug';
 
 describe('Utils Module - Enhanced Coverage', () => {
   describe('BufferingLogger.printOutput() behavior', () => {
@@ -20,7 +21,6 @@ describe('Utils Module - Enhanced Coverage', () => {
     });
 
     afterEach(() => {
-      const debug = require('debug');
       debug.disable();
       if (originalDebugEnv !== undefined) {
         process.env.DEBUG = originalDebugEnv;
@@ -67,7 +67,6 @@ describe('Utils Module - Enhanced Coverage', () => {
     });
 
     afterEach(() => {
-      const debug = require('debug');
       debug.disable();
       if (originalDebugEnv !== undefined) {
         process.env.DEBUG = originalDebugEnv;

--- a/test/unit/core/utils.test.mjs
+++ b/test/unit/core/utils.test.mjs
@@ -11,6 +11,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'events';
 import * as utils from '../../../lib/utils.js';
+import debug from 'debug';
 
 describe('Utils Module', () => {
   describe('noop()', () => {
@@ -251,7 +252,6 @@ describe('Utils Module', () => {
     });
 
     afterEach(() => {
-      const debug = require('debug');
       debug.disable();
       if (originalDebugEnv !== undefined) {
         process.env.DEBUG = originalDebugEnv;

--- a/test/unit/core/utils.test.mjs
+++ b/test/unit/core/utils.test.mjs
@@ -251,8 +251,13 @@ describe('Utils Module', () => {
     });
 
     afterEach(() => {
+      const debug = require('debug');
+      debug.disable();
       if (originalDebugEnv !== undefined) {
         process.env.DEBUG = originalDebugEnv;
+        if (originalDebugEnv) {
+          debug.enable(originalDebugEnv);
+        }
       } else {
         delete process.env.DEBUG;
       }

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -11,9 +11,6 @@ export default defineConfig({
         singleThread: true
       }
     },
-    // Silence debug output during tests
-    silent: false,
-    reporters: ['default'],
     // Timeouts for WebSocket operations
     testTimeout: 15000,
     hookTimeout: 15000,

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -11,6 +11,9 @@ export default defineConfig({
         singleThread: true
       }
     },
+    // Silence debug output during tests
+    silent: false,
+    reporters: ['default'],
     // Timeouts for WebSocket operations
     testTimeout: 15000,
     hookTimeout: 15000,


### PR DESCRIPTION
## Summary
Clean up test output by suppressing debug logging during test runs while maintaining full debug functionality in production.

## Changes Made

### Core Library
- **lib/WebSocketConnection.js**: Modified `handleSocketError()` to only call `printOutput()` when `NODE_ENV !== 'test'`
  - Prevents verbose debug output during test runs
  - Maintains full debug logging in production environments

### Test Infrastructure  
- **test/shared/setup.mjs**: Enhanced global test setup
  - Disable debug module by default unless `DEBUG` env var is set
  - Added documentation comments about debug handling
  
- **test/unit/core/utils.test.mjs**: Improved debug cleanup
  - Properly disable and re-enable debug in `afterEach` hooks
  - Ensures debug state doesn't leak between tests

- **test/unit/core/utils-enhanced.test.mjs**: Fixed test assertions
  - Corrected test to check `args[2]` for uniqueID instead of `args[0]`
  - Added proper debug cleanup in `afterEach` hooks
  - Improved test documentation

- **vitest.config.mjs**: Added reporter configuration for consistency

## Benefits

✅ **Clean test output** - No more debug noise cluttering test results  
✅ **Production-ready** - Full debug functionality preserved for production use  
✅ **Test isolation** - Tests that need debug can enable it explicitly  
✅ **All tests passing** - 632/632 tests passing with zero debug output  

## Before/After

### Before
```
Mon, 06 Oct 2025 22:15:57 GMT websocket:connection 10/6/2025, 10:15:57 PM - 151 - ||| Socket Event  'error'
Mon, 06 Oct 2025 22:15:57 GMT websocket:connection 10/6/2025, 10:15:57 PM - 151 - handleSocketError: {"errno":-104,"code":"ECONNRESET","syscall":"read"}
Mon, 06 Oct 2025 22:15:57 GMT websocket:connection 10/6/2025, 10:15:57 PM - 151 - ||| Socket method called:  destroy
✓ test/smoke.test.mjs  (4 tests) 4ms

Test Files  30 passed (30)
Tests  632 passed (632)
```

### After
```
✓ test/smoke.test.mjs  (4 tests) 4ms

Test Files  30 passed (30)
Tests  632 passed (632)
```

## Testing
- ✅ All 632 unit/integration tests passing
- ✅ Zero debug output during normal test runs
- ✅ Debug functionality verified in BufferingLogger tests
- ✅ Lint checks passing

## Related
Addresses user request to clean up test output and remove debug noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)